### PR TITLE
Fix issue when syncing specialist skills

### DIFF
--- a/app/models/concerns/airtable/base.rb
+++ b/app/models/concerns/airtable/base.rb
@@ -75,10 +75,9 @@ class Airtable::Base < Airrecord::Table
       instance_exec(model, &self.class.sync_block) if self.class.sync_block
 
       unless model.save
-        Rollbar.warning("
-          Failed to sync #{self.class.sync_model.to_s.underscore} #{id} \n
-          #{model.errors.full_messages}
-        ")
+        message = "Failed to sync #{self.class.sync_model.to_s.underscore} #{id} \n#{model.errors.full_messages}"
+        Rails.logger.warn(message)
+        Rollbar.warning(message)
       end
 
       Webhook.process(model)

--- a/app/models/concerns/airtable/specialist.rb
+++ b/app/models/concerns/airtable/specialist.rb
@@ -26,6 +26,8 @@ class Airtable::Specialist < Airtable::Base
     specialist_skills.each do |specialist_skill_id|
       # fetch the specialist skill airtable record
       specialist_skill = Airtable::SpecialistSkill.find(specialist_skill_id)
+      # Go to the next record if their is no associated skill.
+      next if specialist_skill[:skill].nil?
       # get the associated skill record
       skill_id = specialist_skill[:skill][0]
       # check if we already have a synced record of that skill.


### PR DESCRIPTION
Some specialist skill records do not have an attached skill. This was
throwing an error and therefore haulting the syncing process. This fixes
the issue by ignoring any specialist skills that dont have an associated
skill.