### PR TITLE
Remove image field from specialist admin dashboard

### DIFF
--- a/app/dashboards/specialist_dashboard.rb
+++ b/app/dashboards/specialist_dashboard.rb
@@ -58,7 +58,6 @@ class SpecialistDashboard < Administrate::BaseDashboard
     :skills,
     :first_name,
     :last_name,
-    :image,
     :linkedin,
     :travel_availability,
     :city,


### PR DESCRIPTION
When editing a specialist from the admin dashboard, the image was
included as a text input. When the specialist had no avatar ( i.e nil )
the form would submit an empty string as the avatar value. This would
then cause an error in graphQL when fetching applicants.