### PR TITLE
Reduce rollbar sync warnings to a single warning

### DIFF
--- a/app/models/concerns/airtable.rb
+++ b/app/models/concerns/airtable.rb
@@ -1,8 +1,18 @@
 module Airtable
   def self.sync
     Rails.application.eager_load!
+    report = Airtable::SyncReport.new
     Airtable::Base.descendants.each do |table|
-      table.sync
+      table.sync(report)
+    end
+
+    if report.failures.any?
+      output = "Some records failed to sync \n"
+      report.failures.each do |failure|
+        output += "#{failure[:type]} #{failure[:id]}: #{failure[:errors]}\n"
+      end
+      Rollbar.warn(output)
+      puts output
     end
   end
 end

--- a/app/models/concerns/airtable/sync_report.rb
+++ b/app/models/concerns/airtable/sync_report.rb
@@ -1,0 +1,15 @@
+class Airtable::SyncReport
+  attr_reader :failures
+
+  def initialize
+    @failures = []
+  end
+
+  def failed(id, type, errors)
+    @failures << {
+      id: id,
+      type: type,
+      errors: errors
+    }
+  end
+end


### PR DESCRIPTION
Now a single rollbar message will be output at the end of each sync
attempt instead of a message per failure