### PR TITLE
Fix airtable error when attempting to sync user with duplicate skills

### DIFF
--- a/app/models/concerns/airtable/project.rb
+++ b/app/models/concerns/airtable/project.rb
@@ -59,7 +59,7 @@ class Airtable::Project < Airtable::Base
     self['Qualification Question 1'] = project.questions.try(:[], 0) if project.saved_change_to_questions?
     self['Qualification Question 2'] = project.questions.try(:[], 1) if project.saved_change_to_questions?
     self['Accepted Terms'] = project.accepted_terms if project.saved_change_to_accepted_terms_at?
-    self['Skills Required'] = project.skills.map(&:airtable_id)
+    self['Skills Required'] = project.skills.map(&:airtable_id).uniq
     self['Primary Skill Required'] = project.primary_skill
   end
 

--- a/app/models/concerns/airtable/specialist.rb
+++ b/app/models/concerns/airtable/specialist.rb
@@ -62,7 +62,7 @@ class Airtable::Specialist < Airtable::Base
   push_data do |specialist|
     self['Biography'] = specialist.bio
     self['Email Address'] = specialist.email
-    self['Specialist Skills'] = specialist.skills.map(&:airtable_id)
+    self['Specialist Skills'] = specialist.skills.map(&:airtable_id).uniq
     self['City'] = specialist.city
     self['Account Created'] = specialist.has_account? ? "Yes" : nil
     self['Country'] = [specialist.country.try(:airtable_id)]


### PR DESCRIPTION
When a user has added the same skill twice, Airtable refuses the update
request due to the duplicate Id. This calls uniq on the skills array
ensuring that airtable will always receive a unique array.