### PR TITLE
Fix 500 error for some payment intent webhooks

### DIFF
--- a/app/models/concerns/stripe_events/payment_intent_succeeded.rb
+++ b/app/models/concerns/stripe_events/payment_intent_succeeded.rb
@@ -22,7 +22,7 @@ class StripeEvents::PaymentIntentSucceeded < StripeEvents::BaseEvent
   # We store the payment type inside of the payment intent metadata in stripe.
   # e.g Deposit payments will have a payment type of 'deposit'
   def payment_type
-    payment_intent.metadata.payment_type
+    payment_intent.metadata.try(:payment_type)
   end
 
   def payment_intent

--- a/app/services/users/attach_payment_method.rb
+++ b/app/services/users/attach_payment_method.rb
@@ -7,10 +7,18 @@ class Users::AttachPaymentMethod < ApplicationService
   end
 
   def call
-    # Attach the payment method to the customer
-    Stripe::PaymentMethod.attach(payment_method_id, {
-      customer: user.stripe_customer_id
-    })
+    existing = Stripe::PaymentMethod.list(
+      customer: user.stripe_customer_id,
+      type: "card"
+    )
+
+    ids = existing.data.map(&:id)
+    unless ids.include?(payment_method_id)
+      # Attach the payment method to the customer
+      Stripe::PaymentMethod.attach(payment_method_id, {
+        customer: user.stripe_customer_id
+      })
+    end
 
     # Set the payment method as the customer's default payment method
     Stripe::Customer.update(user.stripe_customer_id, {


### PR DESCRIPTION
When payment intents are created off platform, e.g through the
stripe dashboard, they don't have any metadata. This was causing
an error when the webhook tried to access the metadata.

This also fixes an issue when attempting to attach a card that
has already been attached to a customer.