### PR TITLE
Fix error in user policy when user not logged in

### DIFF
--- a/app/policies/user_policy.rb
+++ b/app/policies/user_policy.rb
@@ -10,6 +10,7 @@ class UserPolicy < BasePolicy
   # Checks if the viewer ( as a specialist ) has applied to any of the users
   # projects
   def is_candidate_for_user_project
+    return false unless user.present?
     user.projects.where(user: record).any?
   end
 end


### PR DESCRIPTION
The is_candidate_for_user_project method on the UserPolicy throws an
error if there is no user logged in. This change makes the method
return false if there is no user logged in.