### PR TITLE
Fix bug when task has null estimates

### DIFF
--- a/app/javascript/src/components/TaskDrawer/ErrorBoundary.js
+++ b/app/javascript/src/components/TaskDrawer/ErrorBoundary.js
@@ -1,0 +1,57 @@
+import React from "react";
+import { Box, Icon, Text } from "@advisable/donut";
+
+class TaskDrawerErrorBoundary extends React.Component {
+  state = {
+    hasError: false,
+  };
+
+  componentDidCatch(error, info) {
+    this.setState({ hasError: true });
+  }
+
+  render() {
+    if (this.state.hasError)
+      return (
+        <Box
+          py="xl"
+          height="100%"
+          display="flex"
+          alignItems="center"
+          flexDirection="column"
+          justifyContent="center"
+        >
+          <Box maxWidth={400}>
+            <Box
+              width={50}
+              height={50}
+              bg="yellow.0"
+              display="flex"
+              margin="0 auto"
+              borderRadius="50%"
+              alignItems="center"
+              justifyContent="center"
+            >
+              <Icon icon="alert-circle" color="yellow.6" />
+            </Box>
+            <Text textAlign="center" mb="xxs" mt="m" fontWeight="medium">
+              Could not load task
+            </Text>
+            <Text
+              fontSize="s"
+              lineHeight="s"
+              color="neutral.6"
+              textAlign="center"
+            >
+              An unexpected error has occured. We have been notified and are
+              working to fix the problem.
+            </Text>
+          </Box>
+        </Box>
+      );
+
+    return this.props.children;
+  }
+}
+
+export default TaskDrawerErrorBoundary;

--- a/app/javascript/src/components/TaskDrawer/index.js
+++ b/app/javascript/src/components/TaskDrawer/index.js
@@ -27,6 +27,7 @@ import {
   updateTaskEstimate as UPDATE_ESTIMATE,
   updateTaskDescription as UPDATE_DESCRIPTION,
 } from "../../graphql/mutations/tasks";
+import TaskDrawerErrorBoundary from "./ErrorBoundary";
 
 const DELETE_PROMPT = "DELETE_PROMPT";
 const APPROVE_PROMPT = "APPROVE_PROMPT";
@@ -104,83 +105,85 @@ const Component = ({
                   )
             }
           >
-            <TaskDrawer>
-              {query.loading && (
-                <Padding size="l">
-                  <Padding bottom="l">
-                    <SkeletonHeading />
+            <TaskDrawerErrorBoundary>
+              <TaskDrawer>
+                {query.loading && (
+                  <Padding size="l">
+                    <Padding bottom="l">
+                      <SkeletonHeading />
+                    </Padding>
+                    <SkeletonText />
                   </Padding>
-                  <SkeletonText />
-                </Padding>
-              )}
+                )}
 
-              {prompt === DELETE_PROMPT && (
-                <DeletePrompt
-                  task={task}
-                  onClose={() => setPrompt(null)}
-                  onDelete={handleDelete}
-                />
-              )}
+                {prompt === DELETE_PROMPT && (
+                  <DeletePrompt
+                    task={task}
+                    onClose={() => setPrompt(null)}
+                    onDelete={handleDelete}
+                  />
+                )}
 
-              {prompt === ASSIGN_PROMPT && (
-                <AssignPrompt
-                  task={task}
-                  onClose={() => setPrompt(null)}
-                  onAssign={() => setPrompt(null)}
-                />
-              )}
+                {prompt === ASSIGN_PROMPT && (
+                  <AssignPrompt
+                    task={task}
+                    onClose={() => setPrompt(null)}
+                    onAssign={() => setPrompt(null)}
+                  />
+                )}
 
-              {prompt === APPROVE_PROMPT && (
-                <ApprovePrompt
-                  task={task}
-                  onClose={() => setPrompt(null)}
-                  onApprove={() => {
-                    if (Boolean(task.repeat)) {
-                      setPrompt(REPEAT_PROMPT);
-                    } else {
+                {prompt === APPROVE_PROMPT && (
+                  <ApprovePrompt
+                    task={task}
+                    onClose={() => setPrompt(null)}
+                    onApprove={() => {
+                      if (Boolean(task.repeat)) {
+                        setPrompt(REPEAT_PROMPT);
+                      } else {
+                        setPrompt(null);
+                      }
+                    }}
+                  />
+                )}
+
+                {prompt === SUBMIT_PROMPT && (
+                  <SubmitPrompt
+                    task={task}
+                    onClose={() => setPrompt(null)}
+                    onSubmit={() => {
                       setPrompt(null);
-                    }
-                  }}
-                />
-              )}
+                    }}
+                  />
+                )}
 
-              {prompt === SUBMIT_PROMPT && (
-                <SubmitPrompt
-                  task={task}
-                  onClose={() => setPrompt(null)}
-                  onSubmit={() => {
-                    setPrompt(null);
-                  }}
-                />
-              )}
+                {prompt === REPEAT_PROMPT && (
+                  <RepeatPrompt
+                    task={task}
+                    onClose={() => setPrompt(null)}
+                    onRepeat={task => {
+                      history.replace(task.id);
+                      if (onCreateRepeatingTask) {
+                        onCreateRepeatingTask(task);
+                      }
+                      setPrompt(null);
+                    }}
+                  />
+                )}
 
-              {prompt === REPEAT_PROMPT && (
-                <RepeatPrompt
-                  task={task}
-                  onClose={() => setPrompt(null)}
-                  onRepeat={task => {
-                    history.replace(task.id);
-                    if (onCreateRepeatingTask) {
-                      onCreateRepeatingTask(task);
-                    }
-                    setPrompt(null);
-                  }}
-                />
-              )}
-
-              {!query.loading && (
-                <EditTask
-                  isSaving={isSaving}
-                  readOnly={readOnly}
-                  isClient={isClient}
-                  hideStatus={hideStatus}
-                  onSave={handleSave}
-                  task={query.data.task}
-                  setPrompt={setPrompt}
-                  showStatusNotice={showStatusNotice}
-                />
-              )}
-            </TaskDrawer>
+                {!query.loading && (
+                  <EditTask
+                    isSaving={isSaving}
+                    readOnly={readOnly}
+                    isClient={isClient}
+                    hideStatus={hideStatus}
+                    onSave={handleSave}
+                    task={query.data.task}
+                    setPrompt={setPrompt}
+                    showStatusNotice={showStatusNotice}
+                  />
+                )}
+              </TaskDrawer>
+            </TaskDrawerErrorBoundary>
           </Drawer>
         );
       }}

--- a/app/javascript/src/utilities/currency.js
+++ b/app/javascript/src/utilities/currency.js
@@ -4,8 +4,8 @@ const defaultOptions = {
   format: "$0,0.00",
 };
 
-export default (amount, options = {}) => {
-  const dinero = new Dinero({ currency: "USD", amount: parseInt(amount) });
+export default (amount = 0, options = {}) => {
+  const dinero = new Dinero({ currency: "USD", amount: parseInt(amount || 0) });
   const opts = { ...defaultOptions, ...options };
   return dinero.toFormat(opts.format);
 };

--- a/app/javascript/src/utilities/tasks.js
+++ b/app/javascript/src/utilities/tasks.js
@@ -14,11 +14,11 @@ export const hoursLabel = task => {
 // displays the estimate or hours worked for a task.
 export const hoursDisplay = task => {
   if (hasBeenSubmitted(task)) {
-    return pluralize(task.hoursWorked, "hour", "hours");
+    return pluralize(task.hoursWorked || 0, "hour", "hours");
   }
 
-  if (Boolean(task.flexibleEstimate)) {
-    return `${task.estimate}-${task.flexibleEstimate} hours`;
+  if (task.flexibleEstimate) {
+    return `${task.estimate || 0}-${task.flexibleEstimate || 0} hours`;
   }
 
   return pluralize(task.estimate, "hour", "hours");


### PR DESCRIPTION
When a task is in a submitted state and has Nan for
hoursWorked it would raise an error and cause the page to crash. This
add's an error boundary around the task drawer so that it won't crash
the entire page and render $0 for Nan amounts.