### PR TITLE
Only update user data on specialist search if user is a client

### DIFF
--- a/app/javascript/src/views/ClientSignup/index.js
+++ b/app/javascript/src/views/ClientSignup/index.js
@@ -1,12 +1,19 @@
 import React from "react";
 import { get, find } from "lodash";
 import { Box } from "@advisable/donut";
-import { Switch, Route, matchPath, useLocation } from "react-router-dom";
+import {
+  Switch,
+  Route,
+  Redirect,
+  matchPath,
+  useLocation,
+} from "react-router-dom";
 import Criteria from "./Criteria";
 import PriceRange from "./PriceRange";
 import SaveSearch from "./SaveSearch";
 import Specialists from "./Specialists";
 import Testimonials from "./Testimonials";
+import useViewer from "../../hooks/useViewer";
 
 const STEPS = [
   {
@@ -33,7 +40,13 @@ const STEPS = [
 
 // Renders the various stages of the client signup flow.
 const ClientSignup = () => {
+  const viewer = useViewer();
   const location = useLocation();
+
+  if (viewer?.__typename === "Specialist") {
+    return <Redirect to="/" />;
+  }
+
   const current = find(STEPS, step => {
     return matchPath(location.pathname, { path: step.path });
   });

--- a/app/services/specialists/search.rb
+++ b/app/services/specialists/search.rb
@@ -1,7 +1,19 @@
 class Specialists::Search < ApplicationService
-  attr_accessor :skill, :industry, :company_type, :user, :industry_required, :company_type_required
+  attr_accessor :skill,
+                :industry,
+                :company_type,
+                :user,
+                :industry_required,
+                :company_type_required
 
-  def initialize(skill:, industry:, company_type:, user:, industry_required:, company_type_required:)
+  def initialize(
+    skill:,
+    industry:,
+    company_type:,
+    user:,
+    industry_required:,
+    company_type_required:
+  )
     @skill = skill
     @industry = industry
     @company_type = company_type
@@ -20,8 +32,10 @@ class Specialists::Search < ApplicationService
 
   # Update the users industry and company type based on their search
   def update_user_info
-    return unless user.present?
-    user.update(industry: Industry.find_by_name(industry), company_type: company_type)
+    return unless user.present? && user.is_a?(User)
+    user.update(
+      industry: Industry.find_by_name(industry), company_type: company_type
+    )
     user.sync_to_airtable
   end
 
@@ -53,8 +67,8 @@ class Specialists::Search < ApplicationService
       Specialist.joins(off_platform_projects: :skills).where(
         'average_score >= ?',
         65.0
-    )
-      .where(off_platform_projects: { skills: { name: skill } })
+      )
+        .where(off_platform_projects: { skills: { name: skill } })
         .where
         .not(hourly_rate: nil)
     query = filter_industry(query)
@@ -66,7 +80,7 @@ class Specialists::Search < ApplicationService
     return query unless industry_required
     joined = query.left_outer_joins(:off_platform_projects, :projects)
     joined.where(off_platform_projects: { industry: industry }).or(
-                   joined.where(projects: { industry: industry })
+      joined.where(projects: { industry: industry })
     )
   end
 


### PR DESCRIPTION
This also prevents specialists from entering the /clients/signup flow