### PR TITLE
Fix bug preventing more times being requested

### DIFF
--- a/app/graphql/mutations/request_more_interview_times.rb
+++ b/app/graphql/mutations/request_more_interview_times.rb
@@ -4,10 +4,16 @@ class Mutations::RequestMoreInterviewTimes < Mutations::BaseMutation
 
   field :interview, Types::Interview, null: true
 
+  ALLOWED_STATUSES = [
+    'Call Requested',
+    'Need More Time Options',
+    'More Time Options Added'
+  ]
+
   def resolve(**args)
     interview = Interview.find_by_airtable_id!(args[:id])
 
-    if interview.status != 'Call Requested'
+    unless ALLOWED_STATUSES.include?(interview.status)
       raise ApiError::InvalidRequest.new(
               'interview.notRequested',
               'Interview is not in a requested state'


### PR DESCRIPTION
When an interview has a status of 'More Time Options Added' it was preventing the freelancer requesting more times a second time.