### PR TITLE
Fix failing spec for setCoverPhoto

### DIFF
--- a/spec/graphql/mutations/set_cover_photo_spec.rb
+++ b/spec/graphql/mutations/set_cover_photo_spec.rb
@@ -1,6 +1,6 @@
 require 'rails_helper'
 
-describe Mutations::SetCoverPhoto do
+RSpec.describe Mutations::SetCoverPhoto do
   let(:specialist) { create(:specialist) }
   let(:context) { {current_user: specialist} }
 


### PR DESCRIPTION
After merging into master the spec failed due to update rspec config
from other branch.