### PR TITLE
Sync 'Community Status' column from airtable to postgres

### DIFF
--- a/app/models/concerns/airtable/specialist.rb
+++ b/app/models/concerns/airtable/specialist.rb
@@ -21,6 +21,7 @@ class Airtable::Specialist < Airtable::Base
   sync_column 'PID', to: :pid
   sync_column 'Campaign Name', to: :campaign_name
   sync_column 'Campaign Source', to: :campaign_source
+  sync_column 'Community Status', to: :community_status
 
   sync_data do |specialist|
     if self['Bank Holder Address']

--- a/app/models/specialist.rb
+++ b/app/models/specialist.rb
@@ -106,6 +106,7 @@ end
 #  campaign_name             :string
 #  campaign_source           :string
 #  city                      :string
+#  community_status          :string
 #  completed_tutorials       :text             default([]), is an Array
 #  confirmation_digest       :string
 #  confirmation_token        :string

--- a/db/migrate/20200916154148_add_community_status_to_specialists.rb
+++ b/db/migrate/20200916154148_add_community_status_to_specialists.rb
@@ -1,0 +1,5 @@
+class AddCommunityStatusToSpecialists < ActiveRecord::Migration[6.0]
+  def change
+    add_column :specialists, :community_status, :string
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2020_09_14_133840) do
+ActiveRecord::Schema.define(version: 2020_09_16_154148) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "pgcrypto"
@@ -686,6 +686,7 @@ ActiveRecord::Schema.define(version: 2020_09_14_133840) do
     t.boolean "test_account"
     t.string "remember_token"
     t.boolean "guild", default: false
+    t.string "community_status"
     t.index ["country_id"], name: "index_specialists_on_country_id"
   end
 


### PR DESCRIPTION
Resolves: [Sync community status column](https://app.asana.com/0/inbox/772541505982206/1194206073763745/1194206293757972)

### Description

Sync's the 'Community Status' column from Airtable to Postgres so that Peter can make use of some Postgres hooks.