### PR TITLE
Use S3 for test images

### DIFF
--- a/app/services/test_data.rb
+++ b/app/services/test_data.rb
@@ -1,6 +1,7 @@
 class TestData
-  def self.dummy_avatar
-    "https://source.unsplash.com/800x600/?face"
+  def self.stock_image
+    n = ["01", "02", "03", "04", "05", "06", "07", "08", "09", "10", "11"].sample
+    "https://advisable-test-assets.s3.eu-central-1.amazonaws.com/stock-photos/#{n}.jpg"
   end
 
   def self.create_specialist(attrs = {})
@@ -15,18 +16,18 @@ class TestData
         s.city = 'Scranton'
       end
 
+    unless specialist.avatar.attached? || attrs.fetch(:avatar, nil).nil?
+      url = attrs.fetch(:avatar)
+      specialist.avatar.attach(
+        io: open(url), filename: File.basename(URI.parse(url).path)
+      )
+    end
+
     if specialist.previous_projects.empty?
       create_previous_project(specialist: specialist)
       create_previous_project(specialist: specialist)
       create_previous_project(specialist: specialist)
       create_previous_project(specialist: specialist)
-    end
-
-    unless specialist.avatar.attached?
-      url = dummy_avatar
-      specialist.avatar.attach(
-        io: open(url), filename: File.basename(URI.parse(url).path)
-      )
     end
 
     specialist
@@ -66,14 +67,14 @@ class TestData
       specialist: previous_project.specialist
     )
 
-    url = dummy_avatar
+    url = "https://advisable-test-assets.s3.eu-central-1.amazonaws.com/characters/toby.png"
     previous_project.contact_image.attach(
       io: open(url), filename: File.basename(URI.parse(url).path)
     )
 
     if [true, false].sample
       image = previous_project.images.create(cover: true)
-      url = 'https://source.unsplash.com/1600x900/?marketing,office'
+      url = stock_image
       image.image.attach(
         io: open(url), filename: File.basename(URI.parse(url).path)
       )
@@ -253,6 +254,7 @@ class TestData
       create_specialist(
         first_name: 'Dwight',
         last_name: 'Schrute',
+        avatar: 'https://advisable-test-assets.s3.eu-central-1.amazonaws.com/characters/dwight.jpg',
         email: 'staging+dwight@advisable.com',
         bio:
           'Dwight Kurt Schrute III (born January 20, 1970) is a fictional character on The Office portrayed by Rainn Wilson. He is one of the highest-ranking salesmen as well as assistant to the regional manager (disputed)[1] at the paper distribution company Dunder Mifflin. Additionally, he is a bed-and-breakfast proprietor at Schrute Farms, a beet plantation owner, and an owner of the business park in which Dunder Mifflin exists. He is notorious for his lack of social skills and common sense, his love for martial arts and the justice system, and his office rivalry with fellow salesman Jim Halpert. He is also known for his romantic relationship with Angela Martin, head of the accounting department. He has at times risen to the position of acting Branch Manager of the Scranton branch, but often serves as a second or third in command as Assistant (to the) Regional Manager. While Dwight was a regional manager in the last few episodes of the series, he named himself the Assistant to the Assistant to the Regional Manager (A.A.R.M). Dwight was also the Vice President of Special Projects Development for the Sabre Corporation, which was the parent company of Dunder Mifflin at the time, but was soon replaced by Todd Packer, who was almost immediately terminated. In the final season, Dwight is offered the position of permanent Regional Manager.'
@@ -265,6 +267,7 @@ class TestData
         first_name: 'Jim',
         last_name: 'Halpert',
         email: 'staging+jim@advisable.com',
+        avatar: 'https://advisable-test-assets.s3.eu-central-1.amazonaws.com/characters/jim.png',
         bio:
           "James 'Jim' Halpert (born October 1, 1978) is a fictional character in the U.S. version of the television sitcom The Office, portrayed by John Krasinski. The character is based on Tim Canterbury from the original version of The Office. The character is also named after a childhood friend of executive producer Greg Daniels. He is introduced as a sales representative at the Scranton branch of paper distribution company Dunder Mifflin, before temporarily transferring to the Stamford branch in the third season. Upon the merger of Scranton and Stamford branches, he becomes Assistant Regional Manager, and later co-manager alongside Michael Scott during the sixth-season episode arc from 'The Promotion' to 'Manager and Salesman'. His character serves as the intelligent, mild-mannered straight man role to Michael, although it is also defined by a rivalrous pranking on fellow salesman Dwight Schrute and a romantic interest in receptionist Pam Beesly, whom he begins dating in the fourth season, marries in the sixth, and has children with in the sixth and eighth. Jim's coworker, Andy Bernard, often calls him by the nickname 'Big Tuna'."
       )
@@ -276,6 +279,7 @@ class TestData
         first_name: 'Darryl',
         last_name: 'Philbin',
         email: 'staging+darryl@advisable.com',
+        avatar: 'https://advisable-test-assets.s3.eu-central-1.amazonaws.com/characters/darryl.png',
         bio:
           "Although he is dry and humorless when dealing with Michael Scott, the office manager, he seems to be a much more relaxed, silly person in social situations. Unlike Michael, Darryl is competent, ambitious, and innovative, and on several occasions late into the series, he promotes ideas to corporate that seem to benefit the company greatly. Michael refers to him as \"Mittah Rogers\"—a nickname which began as \"Regis\" (as Darryl's last name is Philbin, a reference to Regis Philbin who is producer Michael Schur's father-in-law), then \"Reeg\", \"Roger\" and then finally settling on \"Mittah Rogers\".[1] In contrast with this, Darryl almost always calls Michael \"Mike\" instead of by his full name (although he will call him by his full name when he becomes frustrated or annoyed with Michael's immaturity). Being in a position of responsibility in a potentially hazardous work area, he dislikes Michael's disregard for rules or safety, as Michael often disrupts their work schedule and delays their shipments from going out on time. His relationship with Michael is tense, as he is often aggravated by Michael's juvenile antics, as when he stated his greatest fear is that someone would prevent them from getting the shipments out on time. His rapport with the rest of the staff both in the office and warehouse is friendly. He was initially enemies with Andy Bernard but the two eventually become close friends and confidants."
       )
@@ -287,6 +291,7 @@ class TestData
         first_name: 'Pam',
         last_name: 'Beesly',
         email: 'staging+pam@advisable.com',
+        avatar: 'https://advisable-test-assets.s3.eu-central-1.amazonaws.com/characters/pam.jpg',
         bio:
           "Pamela Morgan \"Pam\" Halpert (née Beesly; born March 25, 1979) is a fictional character on The Office, played by Jenna Fischer. Her counterpart in the original UK series of The Office is Dawn Tinsley. Her character is initially the receptionist at the paper distribution company Dunder Mifflin, before becoming a saleswoman and eventually office administrator until she left in the series finale. Her character is shy, growing assertive but amiable, and artistically inclined, and shares a romantic interest with Jim Halpert, whom she begins dating in the fourth season, and eventually, marries and starts a family with as the series continues."
       )
@@ -298,6 +303,7 @@ class TestData
         first_name: 'Ryan',
         last_name: 'Howard',
         email: 'staging+ryan@advisable.com',
+        avatar: 'https://advisable-test-assets.s3.eu-central-1.amazonaws.com/characters/ryan.png',
         bio:
           "Ryan Bailey Howard is a fictional character on the US television series The Office. He is portrayed by the show's writer, director, and executive producer B. J. Novak, and is based upon Ricky Howard from the original British version of The Office (as well as Neil Godwin, during the fourth season).[2] During this time, his role is significantly expanded to that of a main character."
       )
@@ -312,6 +318,7 @@ class TestData
         first_name: 'Erin',
         last_name: 'Hannon',
         email: 'staging+erin@advisable.com',
+        avatar: 'https://advisable-test-assets.s3.eu-central-1.amazonaws.com/characters/erin.jpg',
         bio:
           "Kelly Erin Hannon (born May 1, 1986)[1] is a fictional character from the U.S. comedy television series The Office. She is the office receptionist for the Scranton branch of Dunder Mifflin, a position previously held by Pam Beesly before she quit to go work for the Michael Scott Paper Company. Erin is portrayed by Ellie Kemper. She is an original character, although her closest equivalent in the British version of the series would be Mel the receptionist, who appears briefly in The Office Christmas specials, as Dawn Tinsley's replacement."
       )
@@ -326,6 +333,7 @@ class TestData
         first_name: 'Toby',
         last_name: 'Flenderson',
         email: 'staging+toby@advisable.com',
+        avatar: 'https://advisable-test-assets.s3.eu-central-1.amazonaws.com/characters/toby.png',
         bio:
           'Toby H. Flenderson[1] (born February 22, 1963) is a fictional character in The Office played by Paul Lieberstein. Prior to his termination in the series finale, he was the Human Resources Representative at the Scranton branch of Dunder Mifflin/Sabre. He is generally soft-spoken and mild-mannered.'
       )


### PR DESCRIPTION
Use S3 for test images so to prevent failures when third party API's are unavailable.