### PR TITLE
Fix page crashing when freelancer confirm step fails

### DIFF
--- a/app/javascript/src/views/FreelancerSignup/FreelancingPreferences/index.js
+++ b/app/javascript/src/views/FreelancerSignup/FreelancingPreferences/index.js
@@ -1,4 +1,5 @@
 import React from "react";
+import { Redirect } from "react-router-dom";
 import { Formik, Form, Field } from "formik";
 import { useMutation } from "@apollo/client";
 import { Text, Box, Button, Radio } from "@advisable/donut";
@@ -8,9 +9,15 @@ import CurrencyInput from "../../../components/CurrencyInput";
 import UPDATE_PROFILE from "../updateProfile";
 import validationSchema from "./validationSchema";
 import { ArrowRight } from "@styled-icons/feather";
+import useViewer from "../../../hooks/useViewer";
 
 const FreelancingPreferences = ({ history }) => {
+  const viewer = useViewer();
   const [updateProfile] = useMutation(UPDATE_PROFILE);
+
+  if (!viewer.confirmed) {
+    return <Redirect to="/freelancers/signup/confirm" />;
+  }
 
   const handleSubmit = async (values) => {
     await updateProfile({


### PR DESCRIPTION
Resolves: [Specialist signup confirmation step crashes when confirmation request fails](https://app.asana.com/0/1153066927559129/1194976072924585)

Fix "Cannot read property 'viewer' of null" error on specialist signup confirmation step if API request fails.