### PR TITLE
Put preference on new matches over project.sourcing attribute

### DIFF
--- a/app/javascript/src/views/Project/Inbox.js
+++ b/app/javascript/src/views/Project/Inbox.js
@@ -23,17 +23,17 @@ export default function Inbox({ project }) {
 
   const { accepted, matches, sourcing } = data.project;
 
+  if (matches.length > 0) {
+    return <Matches data={data} project={project} />;
+  }
+
   if (!sourcing && accepted.length > 0) {
     return <RequestedIntroductions accepted={accepted} />;
   }
 
-  if (sourcing && matches.length === 0) {
+  if (sourcing) {
     return <SearchingForMatches />;
   }
 
-  if (!sourcing && matches.length === 0) {
-    return <SourcingDisabled />;
-  }
-
-  return <Matches data={data} project={project} />;
+  return <SourcingDisabled />;
 }


### PR DESCRIPTION
Resolves: [Show pending matches even if project.sourcing is turned off](https://app.asana.com/0/1153066927559129/1196543228222685)

### Description

Always show new matches to the client if there are any.
