### PR TITLE
Reduce Airtable syncing to only sync records changed in last day

### DIFF
--- a/app/models/concerns/airtable/base.rb
+++ b/app/models/concerns/airtable/base.rb
@@ -27,7 +27,7 @@ class Airtable::Base < Airrecord::Table
     # the last day.
     def sync(
       report = nil,
-      filter: "DATETIME_DIFF(TODAY(), LAST_MODIFIED_TIME(), 'days') < 3"
+      filter: "DATETIME_DIFF(TODAY(), LAST_MODIFIED_TIME(), 'days') < 1"
     )
       records = all(filter: filter)
       records.each do |r|


### PR DESCRIPTION
Reduce Airtable sync filter to only fetch records modified within the last day.