### PR TITLE
Dont limit project application based on status

### DIFF
--- a/app/graphql/mutations/apply_for_project.rb
+++ b/app/graphql/mutations/apply_for_project.rb
@@ -9,10 +9,11 @@ class Mutations::ApplyForProject < Mutations::BaseMutation
 
   def resolve(**args)
     project = Project.find_by_uid_or_airtable_id!(args[:project])
-    if project.status != "Brief Confirmed"
+
+    if project.brief_confirmed_at.nil?
       ApiError.invalid_request(
-        code: "PROJECT_IN_A_WRONG_STATE",
-        message: "Project is not in 'Brief Confirmed' state"
+        code: "PROJECT_NOT_CONFIRMED",
+        message: "Project brief has not been confirmed"
       )
     end
 

--- a/spec/graphql/mutations/apply_for_project_spec.rb
+++ b/spec/graphql/mutations/apply_for_project_spec.rb
@@ -2,7 +2,7 @@ require "rails_helper"
 
 RSpec.describe Mutations::ApplyForProject do
   let(:specialist) { create(:specialist) }
-  let(:project) { create(:project, status: "Brief Confirmed") }
+  let(:project) { create(:project, status: "Brief Confirmed", brief_confirmed_at: 2.hours.ago) }
   let(:context) { {current_user: specialist} }
 
   let(:query) do
@@ -60,13 +60,13 @@ RSpec.describe Mutations::ApplyForProject do
       end
     end
 
-    context "wrong project status" do
-      let(:project) { create(:project, status: "Draft") }
+    context "has not been confirmed" do
+      let(:project) { create(:project, brief_confirmed_at: nil) }
 
       it "raises an error" do
         response = AdvisableSchema.execute(query, context: context)
         error = response["errors"].first["extensions"]["code"]
-        expect(error).to eq("PROJECT_IN_A_WRONG_STATE")
+        expect(error).to eq("PROJECT_NOT_CONFIRMED")
       end
     end
 


### PR DESCRIPTION
Instead of preventing applications if the status is not Brief Confirmed, instead check that the project was confirmed at some point.