### PR TITLE
Marking a project on pause and informing involved freelancers

### DIFF
--- a/app/mailers/specialist_mailer.rb
+++ b/app/mailers/specialist_mailer.rb
@@ -31,12 +31,13 @@ class SpecialistMailer < ApplicationMailer
     )
   end
 
-  def project_paused(application)
+  def project_paused(project, application)
+    @project = project
     @application = application
     mail(
-      from: @application.project.user.sales_person.email_with_name,
+      from: @project.user.sales_person.email_with_name,
       to: @application.specialist.account.email,
-      subject: "#{@application.project.primary_skill.name} Project Has Been Paused"
+      subject: "#{@project.primary_skill.name} Project Has Been Paused"
     ) do |format|
       format.html { render layout: false }
     end

--- a/app/models/concerns/airtable/project.rb
+++ b/app/models/concerns/airtable/project.rb
@@ -101,15 +101,6 @@ class Airtable::Project < Airtable::Base
     end
   end
 
-  # After the syncing process has been complete
-  after_sync do |project|
-    if !new_record && project.sales_status_changed? && project.sales_status == "Paused"
-      project.applications.where.not(status: 'Application Rejected').find_each do |application|
-        SpecialistMailer.project_paused(application).deliver_later
-      end
-    end
-  end
-
   push_data do |project|
     self['Client Contacts'] = [project.user.try(:airtable_id)].compact.uniq
     self['Project Stage'] = project[:status]

--- a/app/views/specialist_mailer/project_paused.html.slim
+++ b/app/views/specialist_mailer/project_paused.html.slim
@@ -1,7 +1,7 @@
 p
   | Hi #{@application.specialist.account.first_name},
 p
-  | I just wanted to inform you that project <a href="#{root_url}invites/#{@application.uid}">#{@application.project.primary_skill&.name}</a> that you applied on #{@application.applied_at.to_formatted_s(:short)} has been paused per client's request.
+  | I just wanted to inform you that project <a href="#{root_url}invites/#{@application.uid}" target="_blank">#{@project.primary_skill&.name}</a> that you applied on #{@application.applied_at.to_formatted_s(:short)} has been paused per client's request.
 p
   | As soon I hear from the client and get more information, I will update you on the status.
 p
@@ -11,4 +11,4 @@ p
 p
   | Best,
   br
-  = @application.project.user.sales_person.name
+  = @project.user.sales_person.name

--- a/test/mailers/previews/specialist_mailer_preview.rb
+++ b/test/mailers/previews/specialist_mailer_preview.rb
@@ -16,7 +16,7 @@ class SpecialistMailerPreview < ActionMailer::Preview
 
   def project_paused
     application = Application.order(Arel.sql('RANDOM()')).first
-    SpecialistMailer.project_paused(application)
+    SpecialistMailer.project_paused(application.project, application)
   end
 
   private


### PR DESCRIPTION
Resolves: [Marking a project on pause and informing involved freelancers](https://airtable.com/tblzKtqH2SVFDMJBw/viwbjBqy6YW12N7Rn/recoR1qlvfkTjcX3z?blocks=hide)

### Manual Testing Instructions

Steps:
1. Have a project with candidates
2. Set it to paused
3. Active candidates should get emails

### Before deploy

- [x] Add `Paused` to project statuses on airtable. I guess only @peteradvisable can do that?

### Reviewer Checklist

- [x] PR has a clear title and description
- [ ] Manually tested the changes that the PR introduces
- [x] Changes introduced by the PR are covered by tests of acceptable quality
- [x] Checked the quality of [commit messages](http://chris.beams.io/posts/git-commit/)