### PR TITLE
Make response log a hash so it's prettier in Sentry

### DIFF
--- a/app/jobs/create_linkedin_ad_job.rb
+++ b/app/jobs/create_linkedin_ad_job.rb
@@ -26,7 +26,7 @@ class CreateLinkedinAdJob < ApplicationJob
     Rails.logger.error("You need to Set Up LinkedIn Ads in Admin!")
   rescue LinkedinApi::RequestError => e
     # Do not retry jobs that fail LinkedIn API calls just log to Sentry
-    Raven.capture_message(e.response_log.take(2).join(" "), backtrace: e.backtrace, extra: {response: e.response_log.to_json, project_airtable_id: project.airtable_id})
+    Raven.capture_message("Something went wrong with the LinkedIn API request", backtrace: e.backtrace, extra: {response: e.response_log, project_airtable_id: project.airtable_id})
     Slack.message(channel: "paid_marketing", text: "LinkedIn API job posting *failed* for #{project.name} (##{project.airtable_id})!")
   end
 

--- a/app/models/linkedin_api.rb
+++ b/app/models/linkedin_api.rb
@@ -3,18 +3,17 @@ class LinkedinApi
     attr_reader :response_log, :backtrace
 
     def initialize(response)
-      @response_log = [
-        "Something went wrong with the LinkedIn API request.",
-        "Status: #{response.status}.",
-        "URL: #{response.env.url}",
-        "Request body: #{JSON[response.env.request_body]}",
-        "Headers: #{response.headers}.",
-        "Body: #{response.body}"
-      ]
+      @response_log = {
+        status: response.status,
+        url: response.env.url,
+        request_body: JSON[response.env.request_body],
+        headers: response.headers,
+        body: response.body
+      }
       @backtrace = caller
 
-      Rails.logger.error(response_log.join("\n"))
-      super(response_log.take(2).join(' '))
+      Rails.logger.error(response_log)
+      super("Something went wrong with the LinkedIn API request. Status #{response.status}")
     end
   end
 


### PR DESCRIPTION
Improve `response` here: https://sentry.io/organizations/advisable/issues/1972857319/?project=2021209