### PR TITLE
Allow user sales person to be nil in project setup

### DIFF
--- a/app/javascript/src/views/Project/ProjectSetup/JobPendingReview.js
+++ b/app/javascript/src/views/Project/ProjectSetup/JobPendingReview.js
@@ -9,20 +9,25 @@ export default function PublishJob({ data }) {
 
   return (
     <Box textAlign="center">
-      <Avatar
-        size="xl"
-        name={salesPerson.name}
-        mb="l"
-        mx="auto"
-        url={salesPerson.image}
-      />
+      {salesPerson ? (
+        <Avatar
+          size="xl"
+          name={salesPerson.name}
+          mb="l"
+          mx="auto"
+          url={salesPerson.image}
+        />
+      ) : null}
       <JobSetupStepHeader mb="xs">
-        {salesPerson.firstName} is reviewing your job!
+        {salesPerson
+          ? `${salesPerson.firstName} is reviewing your job!`
+          : "We are reviewing your job!"}
       </JobSetupStepHeader>
       <JobSetupStepSubHeader marginBottom="l">
         We&apos;re making sure that this is a project that&apos;s suitable for
-        our specialists before sending it to them. {salesPerson.firstName} will
-        review it and will let you know once it&apos;s live.
+        our specialists before sending it to them.{" "}
+        {salesPerson ? salesPerson.firstName : "We"} will review it and will let
+        you know once it&apos;s live.
       </JobSetupStepSubHeader>
       <Link to={`/projects/${id}/setup/publish`}>
         <Button variant="subtle">Update Details</Button>


### PR DESCRIPTION
Resolves: [Cannot read property 'name' of null](https://sentry.io/organizations/advisable/issues/1974777639/)

### Description

Some times a users sales person is not set properly. This is a data issue, however, the front-end should still be able to handle cases when the sales person is not set.t

Before                           | After
-------------------------------- | --------------------------------
![image](https://user-images.githubusercontent.com/1512593/96978519-5b4a6c80-1516-11eb-8a72-0c95d8ddca0c.png) | ![image](https://user-images.githubusercontent.com/1512593/96978464-4bcb2380-1516-11eb-80ca-0afb5a2b0fe4.png)