### PR TITLE
The error is still raising. No idea why. This should help

### DIFF
--- a/app/controllers/accounts_controller.rb
+++ b/app/controllers/accounts_controller.rb
@@ -20,6 +20,8 @@ class AccountsController < ApplicationController
     user.save!
 
     render json: {user_uid: user.uid, account_uid: account.uid}
+  rescue ActiveRecord::RecordInvalid => e
+    Raven.capture_exception(e, extra: {params: params})
   end
 
   def specialist
@@ -31,6 +33,8 @@ class AccountsController < ApplicationController
     specialist.save!
 
     render json: {specialist_uid: specialist.uid, account_uid: account.uid}
+  rescue ActiveRecord::RecordInvalid => e
+    Raven.capture_exception(e, extra: {params: params})
   end
 
   private


### PR DESCRIPTION
https://sentry.io/organizations/advisable/issues/1981600456/?project=2021209

This is still raising even though params are empty in sentry.

The only explanation is that something is in that`--data "\"********\"" \`
