### PR TITLE
Sync project goals from airtable to postgres.

### DIFF
--- a/app/models/concerns/airtable/project.rb
+++ b/app/models/concerns/airtable/project.rb
@@ -78,7 +78,7 @@ class Airtable::Project < Airtable::Base
     # We don't sync characteristic values from airtable back to postgres
     # because airtable ( and the old project setup flow ) expects the optional
     # characteristics and required characteristics columns to have different
-    # values, however, the new project flow expects all of the charactersitics
+    # values, however, the new project flow expects all of the characteristics
     # to be inside the 'characteristics' column and the required ones duplicated
     # inside of 'required_characteristics'. Syncing from airtable would
     # overwrite the 'characteristics' value without the required ones.


### PR DESCRIPTION
Sync the airtable 'Goals' column to postgres.

### Reviewer Checklist

- [ ] PR has a clear title and description
- [ ] Manually tested the changes that the PR introduces
- [ ] Changes introduced by the PR are covered by tests of acceptable quality
- [ ] Checked the quality of [commit messages](http://chris.beams.io/posts/git-commit/)


### Other

- Also include comment about why we currently don't sync characteristics from airtable back to postgres.
