### PR TITLE
Update Login flow to allow for redirect query param

### DIFF
--- a/app/javascript/guild/components/AuthenticatedRoute/index.js
+++ b/app/javascript/guild/components/AuthenticatedRoute/index.js
@@ -1,21 +1,29 @@
-import React from "react";
-import { Route } from "react-router-dom";
+import React, { useEffect } from "react";
+import { Route, useLocation } from "react-router-dom";
 import useViewer from "@advisable-main/hooks/useViewer";
+
+function RedirectToLogin() {
+  const location = useLocation();
+
+  useEffect(() => {
+    const path = encodeURIComponent(`/guild${location.pathname}`);
+    window.location.href = `/login?redirect=${path}`;
+  }, [location]);
+
+  return null;
+}
 
 const AuthenticatedRoute = ({ render, component: Component, ...rest }) => {
   const viewer = useViewer();
   const guildUser = viewer?.isSpecialist && viewer?.guild;
 
-  const advisableHost = () => {
-    const { host, protocol } = window.location;
-    return `${protocol}//${host}`;
-  };
-
   return (
     <Route
       {...rest}
       render={(props) => {
-        if (!guildUser) return (window.location.href = advisableHost());
+        if (!guildUser) {
+          return <RedirectToLogin />;
+        }
 
         return Component ? <Component {...props} /> : render(props);
       }}

--- a/app/javascript/src/components/Header/CurrentUser.js
+++ b/app/javascript/src/components/Header/CurrentUser.js
@@ -42,11 +42,11 @@ const CurrentUser = ({ user, onLogout }) => {
         {user.companyName && <span>{user.companyName}</span>}
       </CurrentUserToggle>
       <CurrentUserDropdown open={open}>
+        {user.guild && <a href="/guild">Guild</a>}
         {isClient && <Link to="/settings">Settings</Link>}
         <a href="#" onClick={onLogout}>
           Logout
         </a>
-        {user.guild && <a href="/guild">Guild</a>}
       </CurrentUserDropdown>
     </CurrentUserWrapper>
   );

--- a/app/javascript/src/views/Login/index.js
+++ b/app/javascript/src/views/Login/index.js
@@ -1,7 +1,7 @@
 // Renders the login page
 import React from "react";
 import queryString from "query-string";
-import { Redirect, useHistory } from "react-router-dom";
+import { Redirect } from "react-router-dom";
 import { Formik, Form } from "formik";
 import { useTranslation } from "react-i18next";
 import FormField from "components/FormField";
@@ -28,7 +28,11 @@ const Login = ({ location }) => {
   };
 
   if (viewer) {
-    return <Redirect to={from} />;
+    if (queryParams.redirect) {
+      window.location.href = queryParams.redirect;
+    } else {
+      return <Redirect to={from} />;
+    }
   }
 
   const initialValues = {


### PR DESCRIPTION
The current login flow expects all views to be nested inside of the same react router provider. All of the guild views are inside of a completely separate rails webpacker pack. This means that when a user goes to /guild and is asked to login, they aren't redirected back to guild. This changes the guild AuthenticatedRoute component to pass a redirect query param to the login page. The login page then checks for the presence of a redirect query param after logging in and does a full browser refresh
to that path if present.

### Reviewer Checklist

- [ ] PR has a clear title and description
- [ ] Manually tested the changes that the PR introduces
- [ ] Changes introduced by the PR are covered by tests of acceptable quality
- [ ] Checked the quality of [commit messages](http://chris.beams.io/posts/git-commit/)
