### PR TITLE
Make email argument optional when updating profile info

### DIFF
--- a/app/graphql/mutations/update_profile.rb
+++ b/app/graphql/mutations/update_profile.rb
@@ -3,7 +3,7 @@ class Mutations::UpdateProfile < Mutations::BaseMutation
   argument :primarily_freelance, Boolean, required: false
   argument :hourly_rate, Int, required: false
   argument :number_of_projects, String, required: false
-  argument :email, String, required: true
+  argument :email, String, required: false
   argument :bio, String, required: false
   argument :skills, [String], required: false
   argument :city, String, required: false

--- a/app/javascript/src/components/Notifications/Notification.js
+++ b/app/javascript/src/components/Notifications/Notification.js
@@ -17,7 +17,13 @@ function useTimeout(callback, delay) {
   return timeout;
 }
 
-export default function Notification({ content, timeout = 3000, onTimeout }) {
+function Notification({ content, variant, timeout = 3000, onTimeout }) {
   useTimeout(onTimeout, timeout);
-  return <NotificationCard>{content}</NotificationCard>;
+  return <NotificationCard $variant={variant}>{content}</NotificationCard>;
 }
+
+Notification.defaultProps = {
+  variant: "default",
+};
+
+export default Notification;

--- a/app/javascript/src/components/Notifications/index.js
+++ b/app/javascript/src/components/Notifications/index.js
@@ -20,19 +20,23 @@ export const NotificationsProvider = ({ children }) => {
   const notify = (content, opts = {}) => {
     const id = uniqueId("notification");
     const timeout = opts.timeout || 3000;
+    const variant = opts.variant;
     const onTimeout = () => remove(id);
-    setQueue((items) => [...items, { id, content, timeout, onTimeout }]);
+    setQueue((items) => [
+      ...items,
+      { id, variant, content, timeout, onTimeout },
+    ]);
   };
 
   const variants = {
     initial: {
       opacity: 0,
-      y: 40,
-      scale: 0.4,
+      x: 200,
+      scale: 0.9,
     },
     animate: {
       opacity: 1,
-      y: 0,
+      x: 0,
       scale: 1,
     },
     exit: {

--- a/app/javascript/src/components/Notifications/styles.js
+++ b/app/javascript/src/components/Notifications/styles.js
@@ -1,5 +1,18 @@
 import styled from "styled-components";
+import { variant } from "styled-system";
 import { theme } from "@advisable/donut";
+
+const notificationType = variant({
+  prop: "$variant",
+  variants: {
+    default: {
+      background: theme.colors.neutral900,
+    },
+    error: {
+      background: theme.colors.red600,
+    },
+  },
+});
 
 export const Container = styled.div`
   right: 0;
@@ -14,15 +27,16 @@ export const Container = styled.div`
 `;
 
 export const NotificationCard = styled.div`
+  ${notificationType};
+
   width: 320px;
-  padding: 20px;
+  padding: 12px 16px;
   color: white;
   font-size: 14px;
   font-weight: 500;
   line-height: 20px;
   margin-right: 20px;
   border-radius: 8px;
-  background: ${theme.colors.neutral900};
   box-shadow: 0 5px 10px -5px rgba(6, 24, 51, 0.15),
     0 0 50px 0 rgba(6, 24, 51, 0.15);
 

--- a/app/javascript/src/views/UpdateProfile/Location/index.js
+++ b/app/javascript/src/views/UpdateProfile/Location/index.js
@@ -23,14 +23,24 @@ let Location = () => {
   if (profileQuery.loading || countriesQuery.loading) return <Loading />;
 
   const handleSubmit = async (values, formikBag) => {
-    await mutate({
+    const { errors } = await mutate({
       variables: {
         input: values,
       },
     });
 
-    notifications.notify("Your profile has been updated");
     formikBag.setSubmitting(false);
+
+    if (!errors) {
+      notifications.notify("Your profile has been updated");
+    } else {
+      notifications.notify(
+        "It looks like something went wrong, please try again",
+        {
+          variant: "error",
+        },
+      );
+    }
   };
 
   return (

--- a/spec/system/specialist_settings_spec.rb
+++ b/spec/system/specialist_settings_spec.rb
@@ -1,0 +1,33 @@
+require 'rails_helper'
+
+RSpec.describe 'Specialist settings' do
+  let!(:ireland) { create(:country, name: "Ireland") }
+  let!(:germany) { create(:country, name: "Germany") }
+  let(:specialist) { create(:specialist, city: nil, country: ireland, remote: false) }
+
+  before :each do
+    allow_any_instance_of(Specialist).to receive(:sync_to_airtable)
+  end
+
+  it 'allows specialist to change their location' do
+    authenticate_as specialist
+    visit "/profile/location"
+    fill_in 'city', with: "Dublin"
+    select 'Germany', from: "country"
+    click_on 'Save Changes'
+
+    expect(page).to have_content('Your profile has been updated')
+    expect(specialist.reload.city).to eq("Dublin")
+    expect(specialist.reload.country).to eq(germany)
+  end
+
+  it 'allows specialist to change their email' do
+    authenticate_as specialist
+    visit "/profile"
+    fill_in 'email', with: "update@test.com", fill_options: {clear: :backspace}
+    click_on 'Save Changes'
+
+    expect(page).to have_content('Your profile has been updated')
+    expect(specialist.reload.account.email).to eq("update@test.com")
+  end
+end


### PR DESCRIPTION
### Description

Currently specialists can't update their location due to the email argument being required on the `update_profile` mutation. This mutation is also used on the location settings page and does not pass in the email argument.

I have also included some end to end tests.

### Reviewer Checklist

- [x] PR has a clear title and description
- [ ] Manually tested the changes that the PR introduces
- [x] Changes introduced by the PR are covered by tests of acceptable quality
- [x] Checked the quality of [commit messages](http://chris.beams.io/posts/git-commit/)
