### PR TITLE
Remove To Be Invited status override

### DIFF
--- a/app/models/concerns/airtable/application.rb
+++ b/app/models/concerns/airtable/application.rb
@@ -71,12 +71,12 @@ class Airtable::Application < Airtable::Base
 
     if fields['Answer 1']
       questions <<
-        { question: fields['Question 1'], answer: fields['Answer 1'] }
+        {question: fields['Question 1'], answer: fields['Answer 1']}
     end
 
     if fields['Answer 2']
       questions <<
-        { question: fields['Question 2'], answer: fields['Answer 2'] }
+        {question: fields['Question 2'], answer: fields['Answer 2']}
     end
 
     # If the application questions is not equal to the questions array then set
@@ -97,8 +97,6 @@ class Airtable::Application < Airtable::Base
       return 'Application Accepted'
     end
 
-    # Sync any records with a status of To Be Invited as "Invited To Apply"
-    return 'Invited To Apply' if status == 'To Be Invited'
     status
   end
 


### PR DESCRIPTION
### Description

>Yeh this was a while back! I believe we synced records that were "To Be Invited" as "Invited To Apply" inside of the app because of the syncing delay when people where invited would mean they couldn't actually apply because the status would still be 'To Be Invited' until it was synced. 
>I think it makes to remove this and start syncing records as 'To Be Invited'. Then I think it should be fine to use Postgres to trigger them. The important thing is that the status is set to 'Invited To Apply' by the time the actual invite is sent.

### Reviewer Checklist

- [ ] PR has a clear title and description
- [ ] Manually tested the changes that the PR introduces
- [ ] Changes introduced by the PR are covered by tests of acceptable quality
- [ ] Checked the quality of [commit messages](http://chris.beams.io/posts/git-commit/)