### PR TITLE
Email column is now ignored so self[:email] is always blank

### DIFF
--- a/app/models/concerns/airtable/base.rb
+++ b/app/models/concerns/airtable/base.rb
@@ -113,7 +113,7 @@ class Airtable::Base < Airrecord::Table
       end
 
       self.class.column_associations.each do |association, columns_hash|
-        model.public_send("create_#{association}") if model.public_send(association).blank?
+        model.public_send("build_#{association}") if model.public_send(association).blank?
         association = model.public_send(association)
         columns_hash.each do |column, attr|
           association.public_send("#{attr}=", self[column])

--- a/app/models/concerns/airtable/client_contact.rb
+++ b/app/models/concerns/airtable/client_contact.rb
@@ -29,8 +29,6 @@ class Airtable::ClientContact < Airtable::Base
   sync_association 'Owner', to: :sales_person
 
   sync_data do |user|
-    user.ensure_account_exists
-
     if self['Address']
       # sync the address
       user.address = Address.parse(self['Address']).to_h

--- a/app/models/concerns/airtable/specialist.rb
+++ b/app/models/concerns/airtable/specialist.rb
@@ -30,8 +30,6 @@ class Airtable::Specialist < Airtable::Base
   sync_column 'Community Score', to: :community_score
 
   sync_data do |specialist|
-    specialist.ensure_account_exists
-
     if self['Bank Holder Address']
       # sync the bank holder address
       specialist.bank_holder_address =

--- a/app/models/concerns/specialist_or_user.rb
+++ b/app/models/concerns/specialist_or_user.rb
@@ -7,17 +7,6 @@ module SpecialistOrUser
     self.ignored_columns = Account::MIGRATED_COLUMNS
     include Tutorials
     belongs_to :account
-    before_validation :ensure_account_exists
-  end
-
-  def ensure_account_exists
-    return if self[:email].blank?
-    if account.blank?
-      self.account = Account.find_or_create_by!(email: self[:email])
-    elsif account.new_record?
-      account.email = self[:email]
-      account.save!
-    end
   end
 
   [:find_by_email, :find_by_remember_token].each do |method|


### PR DESCRIPTION
### Description

We're not creating accounts for new specialists/users atm because `self[:email]` is always empty.

Additionally we run `sync_column_to_association` before `sync_data` block so that ensure there was useless.

### Reviewer Checklist

- [ ] PR has a clear title and description
- [ ] Manually tested the changes that the PR introduces
- [ ] Changes introduced by the PR are covered by tests of acceptable quality
- [ ] Checked the quality of [commit messages](http://chris.beams.io/posts/git-commit/)
