### PR TITLE
Destroy account when deleting user/specialist

### DIFF
--- a/app/models/concerns/specialist_or_user.rb
+++ b/app/models/concerns/specialist_or_user.rb
@@ -6,7 +6,7 @@ module SpecialistOrUser
   included do
     self.ignored_columns = Account::MIGRATED_COLUMNS
     include Tutorials
-    belongs_to :account
+    belongs_to :account, dependent: :destroy
   end
 
   [:find_by_email, :find_by_remember_token].each do |method|


### PR DESCRIPTION
We had a duplicated specialist.

```
irb(main):020:0> Specialist.find(7341).destroy
irb(main):021:0> Specialist.find(7212).sync_from_airtable
W, [2020-10-30T15:21:02.065531 #4]  WARN -- : Failed to sync association columns of #<Account:0x000055aced61e7a8> on specialist recXclmEj5uxmGXqB
["Email has already been taken"]
```