### PR TITLE
Add system tests for updating password

### DIFF
--- a/spec/system/specialiset_settings_spec.rb
+++ b/spec/system/specialiset_settings_spec.rb
@@ -63,5 +63,6 @@ RSpec.describe 'Specialist settings' do
     fill_in "passwordConfirmation", with: "changed123"
     click_on "Update password"
     expect(page).to have_content("password has been updated")
+    expect(account.authenticate("changed123")).to be_truthy
   end
 end

--- a/spec/system/user_settings_spec.rb
+++ b/spec/system/user_settings_spec.rb
@@ -11,5 +11,6 @@ RSpec.describe 'User settings' do
     fill_in "passwordConfirmation", with: "changed123"
     click_on "Update password"
     expect(page).to have_content("password has been updated")
+    expect(account.authenticate("changed123")).to be_truthy
   end
 end


### PR DESCRIPTION
I'm conscious that the profile work as some changes made to the settings pages so I wanted to make sure we had system tests to make sure the new update password functionality isn't lost in a rebase!
