### PR TITLE
RuboCop stuff

### DIFF
--- a/app/models/previous_project.rb
+++ b/app/models/previous_project.rb
@@ -27,34 +27,24 @@ class PreviousProject < ApplicationRecord
   belongs_to :specialist
   # If the prpevious project belongs to an application then we know it is a
   # previous project that happened on Advisable.
-  belongs_to :application, required: false
-  belongs_to :reviewed_by, class_name: 'SalesPerson', required: false
+  belongs_to :application, optional: true
+  belongs_to :reviewed_by, class_name: 'SalesPerson', optional: true
 
-  has_many :reviews, as: :project
-  has_many :images,
-           class_name: 'PreviousProjectImage',
-           foreign_key: 'off_platform_project_id'
-  has_one :cover_photo,
-          -> { where cover: true },
-          class_name: 'PreviousProjectImage',
-          foreign_key: 'off_platform_project_id'
+  has_many :reviews, as: :project, dependent: :destroy
+  has_many :images, class_name: 'PreviousProjectImage', foreign_key: 'off_platform_project_id', inverse_of: :previous_project, dependent: :destroy
+  has_one :cover_photo, -> { where cover: true }, class_name: 'PreviousProjectImage', foreign_key: 'off_platform_project_id', inverse_of: :previous_project
 
   # Project skills
   has_many :project_skills, as: :project, dependent: :destroy
   has_many :skills, through: :project_skills
-  has_one :primary_project_skill,
-          -> { where primary: true },
-          as: :project, class_name: 'ProjectSkill'
+  has_one :primary_project_skill, -> { where primary: true }, as: :project, class_name: 'ProjectSkill', inverse_of: :project
   has_one :primary_skill, through: :primary_project_skill, source: :skill
 
   # Project industries
   has_many :project_industries, as: :project, dependent: :destroy
   has_many :industries, through: :project_industries
-  has_one :primary_project_industry,
-          -> { where primary: true },
-          as: :project, class_name: 'ProjectIndustry'
-  has_one :primary_industry,
-          through: :primary_project_industry, source: :industry
+  has_one :primary_project_industry, -> { where primary: true }, as: :project, class_name: 'ProjectIndustry', inverse_of: :project
+  has_one :primary_industry, through: :primary_project_industry, source: :industry
 
   # Scopes
   scope :validated, -> { where(validation_status: 'Validated') }
@@ -66,8 +56,8 @@ class PreviousProject < ApplicationRecord
 
   # Every time a project is created, updated or destroyed we want to update the
   # associated specialists project count.
-  after_save :update_specialist_project_count
   after_destroy :update_specialist_project_count
+  after_save :update_specialist_project_count
 
   def on_platform?
     application_id.present?
@@ -94,7 +84,8 @@ class PreviousProject < ApplicationRecord
 
   # Update the associated specialists project count
   def update_specialist_project_count
-    return unless specialist.present?
+    return if specialist.blank?
+
     specialist.update_project_count
   end
 end

--- a/app/models/previous_project_image.rb
+++ b/app/models/previous_project_image.rb
@@ -2,9 +2,7 @@ class PreviousProjectImage < ApplicationRecord
   include Uid
   uid_prefix 'ppi'
 
-  belongs_to :previous_project,
-             class_name: 'PreviousProject',
-             foreign_key: 'off_platform_project_id'
+  belongs_to :previous_project, class_name: 'PreviousProject', foreign_key: 'off_platform_project_id', inverse_of: :images
   has_one_attached :image
 
   after_destroy :set_first_to_cover, if: :cover


### PR DESCRIPTION
Wanted to work on https://airtable.com/tblzKtqH2SVFDMJBw/viwbjBqy6YW12N7Rn/recW1jEciDrOjaq4y?blocks=hide

So I opened up models and fixed RuboCop errors.

Only to find out, it already works the way that ticket wants in  `SendApplicationInformationJob`:

```
  def specialist_ids_by_skill
    primary_skill = project.primary_skill.specialists.pluck(:id)
    previous_projects = project.primary_skill.previous_projects.pluck(:specialist_id)
    primary_skill | previous_projects
  end
```

But still. I have the RuboCop fixes ready at least 😅 