### PR TITLE
Delete User/Specialist when no Account

### DIFF
--- a/app/models/concerns/airtable/base.rb
+++ b/app/models/concerns/airtable/base.rb
@@ -125,6 +125,7 @@ class Airtable::Base < Airrecord::Table
         message = "Failed to sync association columns of #{association} on #{record_type} #{id} \n#{association.errors.full_messages}"
         Rails.logger.warn(message)
         report.failed(id, record_type, association.errors.full_messages) if report
+        return nil
       end
 
       self.class.associations.each do |column, options|
@@ -201,6 +202,7 @@ class Airtable::Base < Airrecord::Table
     id = self[column].try(:first)
     # if there is no ID then we are done.
     return unless id
+
     # use rails reflect_on_association metod to find the association class.
     reflection = record.class.reflect_on_association(attribute)
     association_class = reflection.class_name.constantize

--- a/app/models/concerns/airtable/client_contact.rb
+++ b/app/models/concerns/airtable/client_contact.rb
@@ -11,8 +11,7 @@ class Airtable::ClientContact < Airtable::Base
 
   sync_column 'Title', to: :title
   sync_column 'Project Payment Method', to: :project_payment_method
-  sync_column 'Exceptional Project Payment Terms',
-              to: :exceptional_project_payment_terms
+  sync_column 'Exceptional Project Payment Terms', to: :exceptional_project_payment_terms
   sync_column 'Invoice Name', to: :invoice_name
   sync_column 'Invoice Company Name', to: :invoice_company_name
   sync_column 'Type of Company', to: :company_type
@@ -55,7 +54,16 @@ class Airtable::ClientContact < Airtable::Base
   def sync_budget(user)
     amount = self['Estimated Annual Freelancer Spend (USD)']
     return if amount.nil?
+
     user.budget = amount * 100
+  end
+
+  # After the syncing process has been complete
+  after_sync do |user|
+    if user.account.blank?
+      user.destroy
+      break
+    end
   end
 
   push_data do |user|

--- a/app/models/concerns/airtable/specialist.rb
+++ b/app/models/concerns/airtable/specialist.rb
@@ -85,6 +85,11 @@ class Airtable::Specialist < Airtable::Base
 
   # After the syncing process has been complete
   after_sync do |specialist|
+    if specialist.account.blank?
+      specialist.destroy
+      break
+    end
+
     specialist.saved_change_to_application_stage
     # Deteremine wether or not the specialist record was just created for the
     #  first time.
@@ -206,6 +211,7 @@ class Airtable::Specialist < Airtable::Base
       skill = Skill.find_by_uid_or_airtable_id(id)
 
       return handle_duplicate_skill(skill, record) if skill.present?
+
       # otherwise reraise the error, its a different kind of missing record.
       # possibly a country association or something..
       return false


### PR DESCRIPTION
Resolves: [Ticket](URL)

### Description

We had a couple of specialist with `account_id: nil`. The reasons were duplicated and/or empty emails in airtable.

We should not be saving these.

### Reviewer Checklist

- [ ] PR has a clear title and description
- [ ] Manually tested the changes that the PR introduces
- [ ] Changes introduced by the PR are covered by tests of acceptable quality
- [ ] Checked the quality of [commit messages](http://chris.beams.io/posts/git-commit/)
