### PR TITLE
Soft delete Tasks

### DIFF
--- a/app/graphql/types/application_type.rb
+++ b/app/graphql/types/application_type.rb
@@ -3,9 +3,7 @@ class Types::ApplicationType < Types::BaseType
   field :rate, String, null: true
   field :applied_at, String, null: true
   field :airtable_id, String, null: true
-  field :proposed_at,
-        GraphQL::Types::ISO8601DateTime,
-        null: true, method: :proposal_sent_at
+  field :proposed_at, GraphQL::Types::ISO8601DateTime, null: true, method: :proposal_sent_at
   field :featured, Boolean, null: true
   field :hidden, Boolean, null: true
   field :score, Int, null: true
@@ -41,14 +39,14 @@ class Types::ApplicationType < Types::BaseType
     authorize :read
   end
 
+  def tasks
+    object.tasks.active
+  end
+
   # Return the UID for the application id field. Fall back to the actual 'id'
   # for records that don't have a uid
   def id
     object.uid || object.id
-  end
-
-  def project_type
-    object.project_type
   end
 
   def applied_at
@@ -75,6 +73,7 @@ class Types::ApplicationType < Types::BaseType
   # have included in their application
   def has_more_projects
     return false if object.references.empty?
+
     object.previous_projects.count < object.specialist.previous_projects.count
   end
 end

--- a/app/models/task.rb
+++ b/app/models/task.rb
@@ -26,9 +26,11 @@ class Task < ApplicationRecord
   include Uid
   include Airtable::Syncable
 
-  validates :estimate_type, inclusion: { in: %w[Hourly Fixed] }, allow_nil: true
+  validates :estimate_type, inclusion: {in: %w[Hourly Fixed]}, allow_nil: true
 
   belongs_to :application
+
+  scope :active, -> { where.not(stage: "Deleted") }
 
   # Returns a collection of tasks that have a due date on a given date.
   def self.due_date(date)

--- a/spec/graphql/mutations/delete_task_spec.rb
+++ b/spec/graphql/mutations/delete_task_spec.rb
@@ -4,9 +4,7 @@ RSpec.describe Mutations::DeleteTask do
   let!(:user) { create(:user) }
   let!(:specialist) { create(:specialist) }
   let!(:project) { create(:project, user: user) }
-  let!(:application) do
-    create(:application, specialist: specialist, project: project)
-  end
+  let!(:application) { create(:application, specialist: specialist, project: project) }
   let!(:task) { create(:task, application: application, stage: 'Not Assigned') }
   let(:query) do
     <<-GRAPHQL
@@ -25,21 +23,18 @@ RSpec.describe Mutations::DeleteTask do
     GRAPHQL
   end
 
-  before :each do
-    allow_any_instance_of(Task).to receive(:remove_from_airtable)
-  end
-
   context 'when a user is signed in' do
     it 'deletes the task' do
-      expect {
-        AdvisableSchema.execute(query, context: { current_user: user })
-      }.to change { Task.count }.by(-1)
+      allow_any_instance_of(Task).to receive(:sync_to_airtable)
+      expect(task.reload.stage).not_to eq("Deleted")
+      AdvisableSchema.execute(query, context: {current_user: user})
+      expect(task.reload.stage).to eq("Deleted")
     end
   end
 
   context 'when there is no user signed in' do
     it 'responds with a not_authorized error code' do
-      response = AdvisableSchema.execute(query, context: { current_user: nil })
+      response = AdvisableSchema.execute(query, context: {current_user: nil})
       errors = response['data']['deleteTask']['errors']
       expect(errors[0]['code']).to eq('not_authorized')
     end
@@ -49,7 +44,7 @@ RSpec.describe Mutations::DeleteTask do
     let(:task) { create(:task, application: application, stage: 'Assigned') }
 
     it 'returns an error' do
-      response = AdvisableSchema.execute(query, context: { current_user: user })
+      response = AdvisableSchema.execute(query, context: {current_user: user})
       errors = response['data']['deleteTask']['errors']
       expect(errors[0]['code']).to eq('tasks.cantDeleteAssigned')
     end


### PR DESCRIPTION
Resolves: [Soft Delete Tasks](https://airtable.com/tblzKtqH2SVFDMJBw/viwbjBqy6YW12N7Rn/rec5sCExZQy5JQHHJ?blocks=hide)

### Description

Instead of `destroy` we change task's stage.

Before deploy:

- [x] Add "Deleted" to production Airtable booking tasks

### Reviewer Checklist

- [x] PR has a clear title and description
- [x] Manually tested the changes that the PR introduces
- [x] Changes introduced by the PR are covered by tests of acceptable quality
- [x] Checked the quality of [commit messages](http://chris.beams.io/posts/git-commit/)