### PR TITLE
Restrict ASAP Calls To Working Hours

### DIFF
--- a/app/javascript/src/views/ClientSignup/ClientSignup.test.js
+++ b/app/javascript/src/views/ClientSignup/ClientSignup.test.js
@@ -23,6 +23,19 @@ import {
 } from "./queries";
 
 // Mock data
+const WORK_HOURS_START_INITIAL = process.env.WORK_HOURS_START;
+const WORK_HOURS_END_INITIAL = process.env.WORK_HOURS_END;
+
+beforeAll(() => {
+  process.env.WORK_HOURS_START = "14:00:00+01:00";
+  process.env.WORK_HOURS_END = "21:00:00+01:00";
+});
+
+afterAll(() => {
+  process.env.WORK_HOURS_START = WORK_HOURS_START_INITIAL;
+  process.env.WORK_HOURS_END = WORK_HOURS_END_INITIAL;
+});
+
 const skill = mockData.skill();
 const industry = mockData.industry();
 const mockClientApplication = mockData.clientApplication;

--- a/app/javascript/src/views/ClientSignup/Steps/SignupStatus/AcceptedStatus/index.js
+++ b/app/javascript/src/views/ClientSignup/Steps/SignupStatus/AcceptedStatus/index.js
@@ -24,8 +24,10 @@ function AcceptedStatus({ firstName, lastName }) {
   const fullName = `${firstName} ${lastName}`;
   const { email, applicationId } = useLocationState();
   const modal = useModal();
-  const utcHour = DateTime.utc().hour;
-  const isWorkingRange = utcHour >= 13 && utcHour < 20;
+  const start = DateTime.fromISO(process.env.WORK_HOURS_START);
+  const end = DateTime.fromISO(process.env.WORK_HOURS_END);
+  const now = DateTime.utc();
+  const isWorkingRange = now >= start && now <= end;
 
   const Navigation = useCallback(() => {
     if (callback)


### PR DESCRIPTION
Resolves: [Restrict ASAP Calls To Working Hours](https://airtable.com/tblzKtqH2SVFDMJBw/viwKLVJd9XCARJZfd/recA36m0XSO26wdpL?blocks=hide)

### Description

Marina's working hours are 13-20 UTC, so we should display the `Call Me ASAP` button during that period of time only.
![image](https://user-images.githubusercontent.com/849247/98659350-ae148880-234c-11eb-928d-042b3f61d213.png)

# Additional env variables:
```shell
WORK_HOURS_START=14:00:00+01:00
WORK_HOURS_END=21:00:00+01:00
```

### Manual Testing Instructions

Steps:
1. Go to `/clients/signup`;
2. Walkthrough the form to the fourth step;
3. Make sure that the `Call Me ASAP` button there only during the 13-20 UTC hours range.

### Reviewer Checklist

- [x] PR has a clear title and description
- [ ] Manually tested the changes that the PR introduces
- [ ] Changes introduced by the PR are covered by tests of acceptable quality
- [x] Checked the quality of [commit messages](http://chris.beams.io/posts/git-commit/)

### Screenshots

Before                           | After
-------------------------------- | --------------------------------
[replace with screenshot before] | [replace with screenshot after]

### Other

Provide additional notes, remarks, links, mention specific people to review,…
