### PR TITLE
Create new video call test id's each time cypress tests run

### DIFF
--- a/spec/cypress.json
+++ b/spec/cypress.json
@@ -1,4 +1,5 @@
 {
   "baseUrl": "http://localhost:3000",
-  "defaultCommandTimeout": 10000
+  "defaultCommandTimeout": 10000,
+  "retries": 2
 }

--- a/spec/cypress/app_commands/scenarios/video_call.rb
+++ b/spec/cypress/app_commands/scenarios/video_call.rb
@@ -1,4 +1,0 @@
-User.create(uid: "use_ByJWTfqewHaYhf9", account: Account.create(first_name: "Michael", last_name: "Scott", email: "videocall@test.com", password: "testing123", confirmed_at: 2.hours.ago))
-Specialist.create(uid: "spe_g7JQpZLA0heEGo3", account: Account.create(first_name: "Dwight", last_name: "Schrute", email: "dwight@test.com", password: "testing123", confirmed_at: 2.hours.ago))
-Specialist.create(uid: "spe_4Fq89TaGiQ39Ehn", account: Account.create(first_name: "Jim", last_name: "Halpert", email: "jim@test.com", password: "testing123", confirmed_at: 2.hours.ago))
-call = VideoCall.create(uid: "vid_abcdefghijklmno")

--- a/spec/cypress/integration/video_call.spec.js
+++ b/spec/cypress/integration/video_call.spec.js
@@ -1,19 +1,86 @@
+const nano = require("nanoid"); // eslint-disable-line no-undef
+const uid = nano.customAlphabet(
+  "0123456789abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ",
+  15,
+);
+
 context("A video call", () => {
+  const CALL_ID = `vid_${uid()}`;
+  const MICHAEL_ID = `use_${uid()}`;
+  const DWIGHT_ID = `spe_${uid()}`;
+  const JIM_ID = `spe_${uid()}`;
+
   before(() => {
     cy.app("clean");
-    cy.appScenario("video_call");
+
+    cy.appFactories([
+      [
+        "create",
+        "account",
+        {
+          email: "videocall@test.com",
+          first_name: "Michael",
+          last_name: "Scott",
+          password: "testing123",
+        },
+      ],
+    ]).then((accounts) => {
+      cy.appFactories([
+        ["create", "user", { uid: MICHAEL_ID, account_id: accounts[0].id }],
+      ]);
+    });
+
+    cy.appFactories([
+      [
+        "create",
+        "account",
+        {
+          email: "dwight@test.com",
+          first_name: "Dwight",
+          last_name: "Schrute",
+          password: "testing123",
+        },
+      ],
+    ]).then((accounts) => {
+      cy.appFactories([
+        [
+          "create",
+          "specialist",
+          { uid: DWIGHT_ID, account_id: accounts[0].id },
+        ],
+      ]);
+    });
+
+    cy.appFactories([
+      [
+        "create",
+        "account",
+        {
+          email: "jim@test.com",
+          first_name: "Jim",
+          last_name: "Halpert",
+          password: "testing123",
+        },
+      ],
+    ]).then((accounts) => {
+      cy.appFactories([
+        ["create", "specialist", { uid: JIM_ID, account_id: accounts[0].id }],
+      ]);
+    });
+
+    cy.appFactories([["create", "video_call", { uid: CALL_ID }]]);
   });
 
   describe("when entering a call before the other participant joins", () => {
     beforeEach(() => {
-      cy.visit(`/calls/vid_abcdefghijklmno`);
+      cy.visit(`/calls/${CALL_ID}`);
       cy.get("input[name=email]").type("videocall@test.com");
       cy.get("input[type=password]").type("testing123");
       cy.get("[data-testid=loginButton]").click();
       cy.get("[data-testid=joinCall]").click();
 
       cy.task("addParticipant", {
-        url: "/calls/vid_abcdefghijklmno",
+        url: `/calls/${CALL_ID}`,
         email: "dwight@test.com",
         color: "blue",
       });
@@ -24,25 +91,25 @@ context("A video call", () => {
     });
 
     it("they can see and hear the oter participant", function () {
-      cy.getParticipant("spe_g7JQpZLA0heEGo3").shouldBeColor("blue");
-      cy.getParticipant("spe_g7JQpZLA0heEGo3").shouldBeMakingSound();
+      cy.getParticipant(DWIGHT_ID).shouldBeColor("blue");
+      cy.getParticipant(DWIGHT_ID).shouldBeMakingSound();
     });
 
     it("should remove the participant when they leave", () => {
       cy.task("participantCloseBrowser", "dwight@test.com");
-      cy.getParticipant("spe_g7JQpZLA0heEGo3").should("not.exist");
+      cy.getParticipant(DWIGHT_ID).should("not.exist");
     });
   });
 
   describe("when entering a call after the other participant joins", () => {
     beforeEach(() => {
       cy.task("addParticipant", {
-        url: "/calls/vid_abcdefghijklmno",
+        url: `/calls/${CALL_ID}`,
         email: "dwight@test.com",
         color: "blue",
       });
 
-      cy.visit(`/calls/vid_abcdefghijklmno`);
+      cy.visit(`/calls/${CALL_ID}`);
       cy.get("input[name=email]").type("videocall@test.com");
       cy.get("input[type=password]").type("testing123");
       cy.get("[data-testid=loginButton]").click();
@@ -54,27 +121,27 @@ context("A video call", () => {
     });
 
     it("they can see and hear the oter participant", function () {
-      cy.getParticipant("spe_g7JQpZLA0heEGo3").shouldBeColor("blue");
-      cy.getParticipant("spe_g7JQpZLA0heEGo3").shouldBeMakingSound();
+      cy.getParticipant(DWIGHT_ID).shouldBeColor("blue");
+      cy.getParticipant(DWIGHT_ID).shouldBeMakingSound();
     });
   });
 
   describe("With more than 2 participants", () => {
     beforeEach(() => {
       cy.task("addParticipant", {
-        url: "/calls/vid_abcdefghijklmno",
+        url: `/calls/${CALL_ID}`,
         email: "dwight@test.com",
         color: "blue",
       });
 
-      cy.visit(`/calls/vid_abcdefghijklmno`);
+      cy.visit(`/calls/${CALL_ID}`);
       cy.get("input[name=email]").type("videocall@test.com");
       cy.get("input[type=password]").type("testing123");
       cy.get("[data-testid=loginButton]").click();
       cy.get("[data-testid=joinCall]").click();
 
       cy.task("addParticipant", {
-        url: "/calls/vid_abcdefghijklmno",
+        url: `/calls/${CALL_ID}`,
         email: "jim@test.com",
         color: "red",
       });
@@ -85,10 +152,10 @@ context("A video call", () => {
     });
 
     it("they can see and hear the oter participants", function () {
-      cy.getParticipant("spe_g7JQpZLA0heEGo3").shouldBeColor("blue");
-      cy.getParticipant("spe_4Fq89TaGiQ39Ehn").shouldBeColor("red");
-      cy.getParticipant("spe_g7JQpZLA0heEGo3").shouldBeMakingSound();
-      cy.getParticipant("spe_4Fq89TaGiQ39Ehn").shouldBeMakingSound();
+      cy.getParticipant(DWIGHT_ID).shouldBeColor("blue");
+      cy.getParticipant(JIM_ID).shouldBeColor("red");
+      cy.getParticipant(DWIGHT_ID).shouldBeMakingSound();
+      cy.getParticipant(JIM_ID).shouldBeMakingSound();
     });
   });
 });


### PR DESCRIPTION
### Description

We were hard coding the UID's before to make assertions on the frontend. This caused test runners to interfere with each other. This generates different UID's to use each time instead.

### Reviewer Checklist

- [ ] PR has a clear title and description
- [ ] Manually tested the changes that the PR introduces
- [ ] Changes introduced by the PR are covered by tests of acceptable quality
- [ ] Checked the quality of [commit messages](http://chris.beams.io/posts/git-commit/)
