### PR TITLE
Create video call records when interview is scheduled

### DIFF
--- a/app/graphql/mutations/request_introduction.rb
+++ b/app/graphql/mutations/request_introduction.rb
@@ -11,6 +11,7 @@ class Mutations::RequestIntroduction < Mutations::BaseMutation
     application = Application.find_by_uid_or_airtable_id!(args[:application])
     policy = ApplicationPolicy.new(current_user, application)
     return true if policy.write
+
     ApiError.not_authorized('You do not have access to this')
   end
 
@@ -25,7 +26,7 @@ class Mutations::RequestIntroduction < Mutations::BaseMutation
     update_application_status(application)
     application.project.update_sourcing
 
-    { interview: interview, application: application }
+    {interview: interview, application: application}
   end
 
   private
@@ -36,11 +37,10 @@ class Mutations::RequestIntroduction < Mutations::BaseMutation
         user: application.project.user,
         time_zone: time_zone || current_user.time_zone,
         status: 'Call Requested',
-        call_requested_at: Time.zone.now,
+        call_requested_at: Time.zone.now
       )
 
     interview.sync_to_airtable
-    VideoCall.create(interview: interview)
     interview
   end
 

--- a/app/graphql/mutations/schedule_interview.rb
+++ b/app/graphql/mutations/schedule_interview.rb
@@ -34,6 +34,7 @@ class Mutations::ScheduleInterview < Mutations::BaseMutation
       )
     end
 
+    create_video_call(interview)
     interview.starts_at = args[:starts_at]
     interview.call_scheduled_at = Time.zone.now
     interview.status = "Call Scheduled"
@@ -52,8 +53,15 @@ class Mutations::ScheduleInterview < Mutations::BaseMutation
 
   private
 
+  def create_video_call(interview)
+    return if interview.video_call.present?
+
+    VideoCall.create(interview: interview)
+  end
+
   def update_specialist_number(specialist, number)
     return if specialist.phone == number
+
     specialist.update(phone: number)
     specialist.sync_to_airtable
   end

--- a/spec/graphql/mutations/request_introduction_spec.rb
+++ b/spec/graphql/mutations/request_introduction_spec.rb
@@ -23,7 +23,7 @@ RSpec.describe Mutations::RequestIntroduction do
     GRAPHQL
   end
 
-  let(:context) { { current_user: application.project.user } }
+  let(:context) { {current_user: application.project.user} }
 
   before :each do
     allow_any_instance_of(Interview).to receive(:sync_to_airtable)
@@ -52,14 +52,14 @@ RSpec.describe Mutations::RequestIntroduction do
   end
 
   it 'returns an error if the user is not logged in' do
-    response = AdvisableSchema.execute(query, context: { current_user: nil })
+    response = AdvisableSchema.execute(query, context: {current_user: nil})
     error = response['errors'][0]['extensions']['code']
     expect(error).to eq('notAuthenticated')
   end
 
   it 'returns an error if the user does not have access' do
     response =
-      AdvisableSchema.execute(query, context: { current_user: create(:user) })
+      AdvisableSchema.execute(query, context: {current_user: create(:user)})
     error = response['errors'][0]['extensions']['code']
     expect(error).to eq('notAuthorized')
   end
@@ -68,15 +68,5 @@ RSpec.describe Mutations::RequestIntroduction do
     AdvisableSchema.execute(query, context: context)
     interview = Interview.last
     expect(interview.call_requested_at).to be_within(1.second).of(Time.zone.now)
-  end
-
-  it 'creates a video call' do
-    expect {
-      AdvisableSchema.execute(query, context: context)
-    }.to change {
-      VideoCall.count
-    }.by(1)
-    interview = Interview.last
-    expect(interview.video_call).to_not be_nil
   end
 end

--- a/spec/graphql/mutations/schedule_interview_spec.rb
+++ b/spec/graphql/mutations/schedule_interview_spec.rb
@@ -67,9 +67,19 @@ RSpec.describe Mutations::ScheduleInterview do
     expect(interview.reload.call_scheduled_at).to be_within(1.second).of(Time.zone.now)
   end
 
+  it "creates a video call record" do
+    expect { request }.to(change { VideoCall.count }.by(1))
+  end
+
+  context "when a video call already exists for that interview" do
+    it "doesnt create a video call record" do
+      VideoCall.create(interview: interview)
+      expect { request }.not_to(change { VideoCall.count })
+    end
+  end
 
   context 'when the interview is already scheduled' do
-    let(:status) { "Call Scheduled"}
+    let(:status) { "Call Scheduled" }
 
     it 'returns an error' do
       response = request


### PR DESCRIPTION
Previously we were creating the video call record inside of the requestIntroduction mutation. This is when a client wants to interview an applicant. However, this isn't the only place that we create interview records. We also create interviews inside of the request consultation flow. This moves the video call creation to the scheduleInterview mutation so that the video call will always be created no matter how the interview was requested.

### Reviewer Checklist

- [ ] PR has a clear title and description
- [ ] Manually tested the changes that the PR introduces
- [ ] Changes introduced by the PR are covered by tests of acceptable quality
- [ ] Checked the quality of [commit messages](http://chris.beams.io/posts/git-commit/)