### PR TITLE
Prepare testimonials data in profile's root file

### DIFF
--- a/app/javascript/src/views/FreelancerProfile/FreelancerProfile.test.js
+++ b/app/javascript/src/views/FreelancerProfile/FreelancerProfile.test.js
@@ -25,9 +25,11 @@ const industries = [
 ].map((name) => mockData.industry({ name }));
 const country = mockData.country();
 const countries = [{ ...country, value: country.id, label: country.name }];
+const review = mockData.review();
 const profileProject = mockData.previousProject({
   primarySkill: skills[0],
   primaryIndustry: industries[0],
+  reviews: [review],
   skills: [skills[0], skills[1]],
   industries: [industries[0], industries[1]],
 });
@@ -38,7 +40,6 @@ const profileProjectAlt = mockData.previousProject({
   industries: [industries[2]],
   clientName: "Test Tech",
 });
-const review = mockData.review();
 const specialist = mockData.specialist({
   name: "John Doe",
   projectSkills: {

--- a/app/javascript/src/views/FreelancerProfile/Testimonials/index.js
+++ b/app/javascript/src/views/FreelancerProfile/Testimonials/index.js
@@ -8,11 +8,7 @@ import {
 
 function Testimonials({ reviews }) {
   const isWidescreen = useBreakpoint("sUp");
-  const cards = reviews
-    .filter((review) => !!review.comment)
-    .map((review) => {
-      return <Review key={review.id} review={review} />;
-    });
+  const cards = reviews.map((r) => <Review key={r.id} review={r} />);
   return (
     <Box mb="4xl">
       <SectionHeaderWrapper divider={"neutral200"}>

--- a/app/javascript/src/views/FreelancerProfile/index.js
+++ b/app/javascript/src/views/FreelancerProfile/index.js
@@ -30,7 +30,10 @@ function FreelancerProfile() {
   if (isNotFound(error)) return <NotFound />;
 
   const isOwner = viewer?.id === data.specialist.id;
-  const hasReviews = data.specialist.reviews.length > 0;
+  const reviews = data.specialist.profileProjects
+    .reduce((acc, proj) => [...acc, ...proj.reviews], [])
+    .filter((review) => !!review.comment);
+  const hasReviews = reviews.length > 0;
 
   return (
     <Box
@@ -49,7 +52,7 @@ function FreelancerProfile() {
       {data.specialist.profileProjects.length === 0 && (
         <NoProjects data={data} isOwner={isOwner} />
       )}
-      {hasReviews && <Testimonials reviews={data.specialist.reviews} />}
+      {hasReviews && <Testimonials reviews={reviews} />}
       {!isOwner && <CallToActionBox specialist={data.specialist} />}
     </Box>
   );


### PR DESCRIPTION
### Description

- Retrieve reviews from `profileProjects`. This is a workaround for a backend bug where API returns an empty array of reviews but contains them in `profileProjects`. 

**Visit this profile: https://app.advisable.com/freelancers/recwobJnjd3V0C81K**

![image](https://user-images.githubusercontent.com/849247/98894577-b932fa00-24ad-11eb-879f-b764d856ab45.png)

- Filter empty reviews before passing them down into the `Testimonials` component, to avoid the display of the whole section similar to the issue on the next screenshot made my Marina: 
![image](https://user-images.githubusercontent.com/849247/98895070-d9af8400-24ae-11eb-9350-68b581187355.png)


### Manual Testing Instructions

Steps:
1. Log in as a specialist
2. Go to `/profile` path
3. Check if there are no issues with testimonials in both previous project details and testimonials section.

### Reviewer Checklist

- [ ] PR has a clear title and description
- [ ] Manually tested the changes that the PR introduces
- [ ] Changes introduced by the PR are covered by tests of acceptable quality
- [ ] Checked the quality of [commit messages](http://chris.beams.io/posts/git-commit/)

### Screenshots

Before                           | After
-------------------------------- | --------------------------------
[replace with screenshot before] | [replace with screenshot after]

### Other

Provide additional notes, remarks, links, mention specific people to review,…
