### PR TITLE
Add Ruby Language Metrics

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -11,6 +11,7 @@ gem "strong_migrations"
 gem "good_migrations"
 # Use Puma as the app server
 gem "puma", "~> 4.3.6"
+gem "barnes"
 # Use SCSS for stylesheets
 gem "sass-rails", ">= 6"
 # See https://github.com/rails/execjs#readme for more supported runtimes

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -122,6 +122,9 @@ GEM
       aws-sigv4 (~> 1.1)
     aws-sigv4 (1.2.2)
       aws-eventstream (~> 1, >= 1.0.2)
+    barnes (0.0.8)
+      multi_json (~> 1)
+      statsd-ruby (~> 1.1)
     bcrypt (3.1.16)
     bindex (0.8.1)
     bootsnap (1.4.8)
@@ -443,6 +446,7 @@ GEM
       actionpack (>= 4.0)
       activesupport (>= 4.0)
       sprockets (>= 3.0.0)
+    statsd-ruby (1.4.0)
     stripe (5.26.0)
     strong_migrations (0.7.1)
       activerecord (>= 5)
@@ -496,6 +500,7 @@ DEPENDENCIES
   annotate
   attr_encrypted (~> 3.1.0)
   aws-sdk-s3 (~> 1)
+  barnes
   bcrypt (~> 3.1.7)
   bootsnap (>= 1.4.2)
   byebug

--- a/Procfile
+++ b/Procfile
@@ -1,3 +1,3 @@
-web: bundle exec puma -t 5:5 -p ${PORT:-3000} -e ${RACK_ENV:-development}
+web: bundle exec puma -C config/puma.rb
 worker: bundle exec sidekiq -t 25 -C config/sidekiq.yml
 release: bundle exec rails db:migrate

--- a/config/puma.rb
+++ b/config/puma.rb
@@ -1,38 +1,28 @@
-# Puma can serve each request in a thread from an internal thread pool.
-# The `threads` method setting takes two numbers: a minimum and maximum.
-# Any libraries that use thread pools should be configured to match
-# the maximum value specified for Puma. Default is set to 5 threads for minimum
-# and maximum; this matches the default thread size of Active Record.
-#
-max_threads_count = ENV.fetch("RAILS_MAX_THREADS") { 5 }
-min_threads_count = ENV.fetch("RAILS_MIN_THREADS") { max_threads_count }
-threads min_threads_count, max_threads_count
+require 'barnes'
 
-# Specifies the `port` that Puma will listen on to receive requests; default is 3000.
-#
-port        ENV.fetch("PORT") { 3000 }
+workers Integer(ENV['WEB_CONCURRENCY'] || 2)
+threads_count = Integer(ENV['RAILS_MAX_THREADS'] || 5)
+threads threads_count, threads_count
 
-# Specifies the `environment` that Puma will run in.
-#
-environment ENV.fetch("RAILS_ENV") { "development" }
+preload_app!
+
+rackup      DefaultRackup
+port        ENV['PORT']     || 3000
+environment ENV['RACK_ENV'] || 'development'
+
+on_worker_boot do
+  # Worker specific setup for Rails 4.1+
+  # See: https://devcenter.heroku.com/articles/deploying-rails-applications-with-the-puma-web-server#on-worker-boot
+  ActiveRecord::Base.establish_connection
+end
+
+before_fork do
+  # worker specific setup
+  Barnes.start # Must have enabled worker mode for this to block to be called
+end
 
 # Specifies the `pidfile` that Puma will use.
 pidfile ENV.fetch("PIDFILE") { "tmp/pids/server.pid" }
-
-# Specifies the number of `workers` to boot in clustered mode.
-# Workers are forked web server processes. If using threads and workers together
-# the concurrency of the application would be max `threads` * `workers`.
-# Workers do not work on JRuby or Windows (both of which do not support
-# processes).
-#
-# workers ENV.fetch("WEB_CONCURRENCY") { 2 }
-
-# Use the `preload_app!` method when specifying a `workers` number.
-# This directive tells Puma to first boot the application and load code
-# before forking the application. This takes advantage of Copy On Write
-# process behavior so workers use less memory.
-#
-# preload_app!
 
 # Allow puma to be restarted by `rails restart` command.
 plugin :tmp_restart


### PR DESCRIPTION
https://devcenter.heroku.com/articles/language-runtime-metrics-ruby#getting-started

Turns out we use a very specific puma config with lots of things commented out with no specific reason. It's all coming from the "initial commit" 😅 

So I went with the [currently recommended starting point for puma](https://devcenter.heroku.com/articles/deploying-rails-applications-with-the-puma-web-server), and extended with the existing `pidfile` and `tmp_restart` and added all the  barnes stuff