### PR TITLE
Fix profile redirection

### DIFF
--- a/app/javascript/src/ApplicationRoutes.js
+++ b/app/javascript/src/ApplicationRoutes.js
@@ -116,9 +116,10 @@ const ApplicationRoutes = () => {
             component={ApplicationFlow}
           />
           <AuthenticatedRoute path="/settings" component={Settings} />
-          <AuthenticatedRoute path="/profile">
-            <RedirectToFreelancerProfile />
-          </AuthenticatedRoute>
+          <AuthenticatedRoute
+            path="/profile"
+            component={RedirectToFreelancerProfile}
+          />
           <Route component={NotFound} />
         </Switch>
       </Suspense>

--- a/app/javascript/src/views/FreelancerProfile/FreelancerProfile.test.js
+++ b/app/javascript/src/views/FreelancerProfile/FreelancerProfile.test.js
@@ -1,4 +1,4 @@
-import { fireEvent } from "@testing-library/react";
+import { screen, fireEvent } from "@testing-library/react";
 import generateType from "../../__mocks__/graphqlFields";
 import {
   mockViewer,
@@ -418,4 +418,28 @@ test("Renders 404 if the specialist isn't found", async () => {
   });
   const status = await app.findByText("404");
   expect(status).toBeInTheDocument();
+});
+
+test("going to /profile when not logged in redirects to the login page", async () => {
+  renderRoute({
+    route: "/profile",
+    graphQLMocks: [mockViewer(null)],
+  });
+
+  await screen.findByText(/welcome back/i);
+});
+
+test("going to /profile when logged in redirects to their profile", async () => {
+  renderRoute({
+    route: "/profile",
+    graphQLMocks: [
+      mockViewer(specialist),
+      mockQuery(GET_PROFILE, { id: specialist.id }, { specialist }),
+      mockQuery(GET_COUNTRIES, {}, { countries }),
+    ],
+  });
+
+  await screen.findByText(specialist.name);
+  await screen.findByText(specialist.bio);
+  await screen.findByText(specialist.location);
 });


### PR DESCRIPTION
Resolves: [Ticket](https://sentry.io/organizations/advisable/issues/2025607686/?project=2019647&query=is%3Aunresolved)

### Description

Going to `/profile` when not logged in was throwing an error because our `AuthenticatedRoute` component does not accept children format.

### Reviewer Checklist

- [ ] PR has a clear title and description
- [ ] Manually tested the changes that the PR introduces
- [ ] Changes introduced by the PR are covered by tests of acceptable quality
- [ ] Checked the quality of [commit messages](http://chris.beams.io/posts/git-commit/)