### PR TITLE
Improve error tracking for GraphQL frontend errors

### DIFF
--- a/app/graphql/advisable_schema.rb
+++ b/app/graphql/advisable_schema.rb
@@ -7,6 +7,10 @@ class AdvisableSchema < GraphQL::Schema
     raise ApiError::InvalidRequest.new('notFound', 'Resouce was not found')
   end
 
+  rescue_from(ActiveRecord::RecordInvalid) do |e|
+    raise ApiError::InvalidRequest.new('RECORD_INVALID', e.record.errors.full_messages.first)
+  end
+
   def self.unauthorized_field(error)
     raise GraphQL::ExecutionError.new(
             "Invalid permissions for #{error.field.graphql_name} field",


### PR DESCRIPTION
### Description

Sends a message to sentry every time a GraphQL query returns errors and adds context around the query that was made and the error that was returned.

![Screenshot 2020-11-13 at 11 01 20](https://user-images.githubusercontent.com/1512593/99066832-85390100-25a1-11eb-950e-8e896c763091.png)
![Screenshot 2020-11-13 at 11 01 30](https://user-images.githubusercontent.com/1512593/99066839-89651e80-25a1-11eb-8dca-34218b57c3ec.png)
![Screenshot 2020-11-13 at 11 01 35](https://user-images.githubusercontent.com/1512593/99066842-8a964b80-25a1-11eb-81fb-814eae41ace5.png)


- [ ] PR has a clear title and description
- [ ] Manually tested the changes that the PR introduces
- [ ] Changes introduced by the PR are covered by tests of acceptable quality
- [ ] Checked the quality of [commit messages](http://chris.beams.io/posts/git-commit/)
