### PR TITLE
Allow toggle sourcing to accept airtable_id instead of UID

### DIFF
--- a/app/graphql/mutations/toggle_sourcing.rb
+++ b/app/graphql/mutations/toggle_sourcing.rb
@@ -5,15 +5,16 @@ class Mutations::ToggleSourcing < Mutations::BaseMutation
 
   def authorized?(**args)
     requires_current_user!
-    project = Project.find_by_uid!(args[:project])
+    project = Project.find_by_uid_or_airtable_id!(args[:project])
     policy = ProjectPolicy.new(context[:current_user], project)
     return true if policy.can_access_project?
+
     ApiError.not_authorized('You do not have access to this project')
   end
 
   def resolve(**args)
-    project = Project.find_by_uid!(args[:project])
+    project = Project.find_by_uid_or_airtable_id!(args[:project])
     project.update(sourcing: !project.sourcing)
-    { project: project }
+    {project: project}
   end
 end


### PR DESCRIPTION
Resolves: [Ticket](https://sentry.io/organizations/advisable/issues/2028010098/?project=2019647&query=is%3Aunresolved&statsPeriod=14d)

### Description

Allows `toggleSourcing` mutation to accept either uid or airtable_id. Some project URL's are still using airtable_id's instead of UID's in the URL.

### Reviewer Checklist

- [ ] PR has a clear title and description
- [ ] Manually tested the changes that the PR introduces
- [ ] Changes introduced by the PR are covered by tests of acceptable quality
- [ ] Checked the quality of [commit messages](http://chris.beams.io/posts/git-commit/)
