### PR TITLE
Don't try and publish job again if its already been published

### DIFF
--- a/app/graphql/mutations/publish_project.rb
+++ b/app/graphql/mutations/publish_project.rb
@@ -33,6 +33,7 @@ class Mutations::PublishProject < Mutations::BaseMutation
   def resolve(id:)
     project = Project.find_by_uid_or_airtable_id!(id)
     project.status = project.assisted? ? "Brief Confirmed" : "Pending Advisable Confirmation"
+    project.published_at = Time.zone.now
     project.sales_status = 'Open'
     project.sourcing = true
     project.sync_to_airtable if project.save

--- a/app/graphql/types/project_type.rb
+++ b/app/graphql/types/project_type.rb
@@ -53,6 +53,10 @@ class Types::ProjectType < Types::BaseType
   field :company_type, String, null: true
   field :created_at, GraphQL::Types::ISO8601DateTime, null: false
 
+  field :published_at, GraphQL::Types::ISO8601DateTime, null: true do
+    authorize :is_client
+  end
+
   field :industry_experience_importance, Int, null: true do
     description <<~HEREDOC
       How important indusry experience is for this job. Range from 0 - 3.

--- a/app/javascript/src/testHelpers/mockData.js
+++ b/app/javascript/src/testHelpers/mockData.js
@@ -82,6 +82,7 @@ export const project = (fields = {}) => {
     name: "Project",
     currency: "USD",
     viewerCanAccess: true,
+    publishedAt: null,
     primarySkill: skill({ name: "Testing" }),
     questions: ["Question?"],
     applicationsOpen: true,

--- a/app/javascript/src/views/Project/ProjectSetup/queries.js
+++ b/app/javascript/src/views/Project/ProjectSetup/queries.js
@@ -5,6 +5,7 @@ const projectFields = gql`
     id
     status
     goals
+    publishedAt
     characteristics
     optionalCharacteristics
     requiredCharacteristics

--- a/app/models/project.rb
+++ b/app/models/project.rb
@@ -165,6 +165,7 @@ end
 #  owner                            :string
 #  proposal_received_at             :datetime
 #  proposed_count                   :integer          default(0)
+#  published_at                     :datetime
 #  questions                        :text             default([]), is an Array
 #  remote                           :boolean
 #  required_characteristics         :text             default([]), is an Array

--- a/db/migrate/20201113143045_add_publised_at_to_projects.rb
+++ b/db/migrate/20201113143045_add_publised_at_to_projects.rb
@@ -1,0 +1,5 @@
+class AddPublisedAtToProjects < ActiveRecord::Migration[6.0]
+  def change
+    add_column :projects, :published_at, :datetime
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2020_11_12_215842) do
+ActiveRecord::Schema.define(version: 2020_11_13_143045) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "citext"
@@ -625,6 +625,7 @@ ActiveRecord::Schema.define(version: 2020_11_12_215842) do
     t.boolean "sourcing"
     t.bigint "sales_person_id"
     t.bigint "linkedin_campaign_id"
+    t.datetime "published_at"
     t.index ["client_id"], name: "index_projects_on_client_id"
     t.index ["sales_person_id"], name: "index_projects_on_sales_person_id"
     t.index ["user_id"], name: "index_projects_on_user_id"


### PR DESCRIPTION
Resolves: [Ticket](https://sentry.io/organizations/advisable/issues/2028147350/?project=2019647&query=is%3Aunresolved&statsPeriod=14d)

### Description

After a user has published a job, they can go back and make further changes while it is being reviewed. However, the last step will give an error because the job has technically already been published.

This adds a `published_at` time stamp and prevents the publish step from submitting the API call twice.

### Reviewer Checklist

- [ ] PR has a clear title and description
- [ ] Manually tested the changes that the PR introduces
- [ ] Changes introduced by the PR are covered by tests of acceptable quality
- [ ] Checked the quality of [commit messages](http://chris.beams.io/posts/git-commit/)