### PR TITLE
Improve sentry grouping even more

### DIFF
--- a/app/javascript/src/graphqlClient.js
+++ b/app/javascript/src/graphqlClient.js
@@ -41,9 +41,16 @@ const errorLink = onError(({ graphQLErrors, operation }) => {
           variables: JSON.stringify(operation.variables),
         });
 
-        Sentry.captureMessage(
-          `${name} returned error ${rest.extensions?.code}`,
+        scope.setFingerprint(
+          [
+            "graphql-error",
+            operation.operationName,
+            rest.path.join("."),
+            rest.extensions?.code,
+          ].filter(Boolean),
         );
+
+        Sentry.captureMessage(`${name} returned error`);
       });
     });
   }


### PR DESCRIPTION
Grouping errors by just the operation name and error code is not enough. Some errors are specific to a certain part of the query. i.e a query might return a `PERMISSION_DENIED` error code, however, each instance will be grouped even if the thing that the user does not have access to is different. 

This overrides Sentry's grouping and provides a custom fingerprint made up of "graphql-error", The query name, the path in the query that the error relates to and an error code if one was returned.

![Screenshot 2020-11-16 at 16 30 13](https://user-images.githubusercontent.com/1512593/99280718-9005c700-2829-11eb-99eb-68c28b6ac7ac.png)
![Screenshot 2020-11-16 at 16 31 05](https://user-images.githubusercontent.com/1512593/99280722-9136f400-2829-11eb-9dc6-0170445c660e.png)
![Screenshot 2020-11-16 at 16 35 01](https://user-images.githubusercontent.com/1512593/99280832-b0ce1c80-2829-11eb-83f3-d815d271253c.png)
