### PR TITLE
Sync linkedin changes from app to airtable

### DIFF
--- a/app/models/concerns/airtable/specialist.rb
+++ b/app/models/concerns/airtable/specialist.rb
@@ -110,6 +110,11 @@ class Airtable::Specialist < Airtable::Base
     self['Biography'] = specialist.bio
     self['LinkedIn URL'] = specialist.linkedin
     self['Can Travel'] = specialist.travel_availability
+    self['Community Status'] = specialist.community_status
+    self['Community Status - Applied To Join - Timestamp'] = specialist.community_applied_at
+    self['Community Status - Accepted - Timestamp'] = specialist.community_accepted_at
+    self['Community Status - Invited To Call - Timestamp'] = specialist.community_invited_to_call_at
+    self['Community Score'] = specialist.community_score
     self['Email Address'] = specialist.account.email
     self['First Name'] = specialist.account.first_name
     self['Last Name'] = specialist.account.last_name


### PR DESCRIPTION
When a specialist updates their linkedin URL ( or adds it ) via their profile, we aren't syncing that change to airtable and so it is being overwritten with the previous value the next time airtable syncs.