### PR TITLE
Fix resending confirmation email in freelancer signup flow

### DIFF
--- a/app/javascript/src/views/FreelancerSignup/Confirm/ConfirmationPending.js
+++ b/app/javascript/src/views/FreelancerSignup/Confirm/ConfirmationPending.js
@@ -8,12 +8,11 @@ import { useNotifications } from "../../../components/Notifications";
 
 const RESEND = gql`
   mutation ResendConfirmationEmail {
-    resendConfirmationEmail {
-      user {
-        id
-      }
-      errors {
-        code
+    resendConfirmationEmail(input: {}) {
+      viewer {
+        ... on Specialist {
+          id
+        }
       }
     }
   }


### PR DESCRIPTION
Resolves: [Ticket](https://sentry.io/organizations/advisable/issues/2041784484/?project=2019647&query=is%3Aunresolved)

### Description

After #601 updated the mutations for resending confirmation emails I forgot to also update the freelancer signup flow. This will eventually be removed from the signup flow but this fixes it for now.

### Reviewer Checklist

- [x] PR has a clear title and description
- [ ] Manually tested the changes that the PR introduces
- [ ] Changes introduced by the PR are covered by tests of acceptable quality
- [x] Checked the quality of [commit messages](http://chris.beams.io/posts/git-commit/)