### PR TITLE
Allow for null path when fingerprinting graphql errors

### DIFF
--- a/app/javascript/src/graphqlClient.js
+++ b/app/javascript/src/graphqlClient.js
@@ -45,7 +45,7 @@ const errorLink = onError(({ graphQLErrors, operation }) => {
           [
             "graphql-error",
             operation.operationName,
-            rest.path.join("."),
+            rest.path?.join("."),
             rest.extensions?.code,
           ].filter(Boolean),
         );


### PR DESCRIPTION
Resolves: [Ticket](https://sentry.io/organizations/advisable/issues/2039052294/?project=2019647&query=is%3Aunresolved)

Apparently sometimes `path` can be null. inside of a GraphQL error.. This raised an error in sentry.