### PR TITLE
Fix stack component spacing

### DIFF
--- a/donut/src/components/Stack/styles.js
+++ b/donut/src/components/Stack/styles.js
@@ -2,6 +2,12 @@ import { space } from "styled-system";
 import styled, { css } from "styled-components";
 import theme from "../../theme";
 
+function halfRems(rems) {
+  if (!rems) return 0;
+  const units = parseFloat(rems) / 2;
+  return `${units}rem`;
+}
+
 export const StyledStack = styled.div`
   ${space}
 `;
@@ -11,8 +17,8 @@ const dividerStyles = css`
 `;
 
 export const StyledStackItem = styled.div`
-  padding-top: ${(p) => (theme.space[p.spacing] || p.spacing) / 2}px;
-  padding-bottom: ${(p) => (theme.space[p.spacing] || p.spacing) / 2}px;
+  padding-top: ${(p) => halfRems(theme.space[p.spacing] || p.spacing)};
+  padding-bottom: ${(p) => halfRems(theme.space[p.spacing] || p.spacing)};
   ${(p) => p.divider && dividerStyles};
 
   &:first-child {


### PR DESCRIPTION
The Stack component expected spacing values in px. This updates stack to work with the new rem values.

### Reviewer Checklist

- [ ] PR has a clear title and description
- [ ] Manually tested the changes that the PR introduces
- [ ] Changes introduced by the PR are covered by tests of acceptable quality
- [ ] Checked the quality of [commit messages](http://chris.beams.io/posts/git-commit/)
