### PR TITLE
Change scope for the freelancers guild posts so its similar to the feed

### DIFF
--- a/app/graphql/types/specialist_type.rb
+++ b/app/graphql/types/specialist_type.rb
@@ -226,6 +226,9 @@ class Types::SpecialistType < Types::BaseType
   end
 
   field :guild_posts, Types::Guild::PostInterface.connection_type, null: false
+  def guild_posts
+    object.guild_posts.published.order(created_at: :desc)
+  end
 
   field :guild_joined_time_ago, String, null: true do
     description 'The timestamp in words for when the specialist first joined the guild'

--- a/app/models/concerns/guild/specialists_concern.rb
+++ b/app/models/concerns/guild/specialists_concern.rb
@@ -9,7 +9,7 @@ module Guild
       # specialist.follows.where(followable_type: 'ActsAsTaggableOn::Tag')
       acts_as_follower
 
-      has_many :guild_posts, class_name: 'Guild::Post', dependent: :destroy
+      has_many :guild_posts, class_name: 'Guild::Post', dependent: :destroy, inverse_of: :specialist
       has_many :guild_comments, class_name: 'Guild::Comment', dependent: :destroy
       has_many :guild_post_comments,
                -> { published.order(created_at: :desc) },


### PR DESCRIPTION
* https://www.notion.so/Draft-post-s-should-not-be-shown-on-the-freelancer-s-profile-f4cf6ea7c6334fef929e292b518191cf
* https://www.notion.so/Freelancer-posts-should-be-ordered-by-date-published-or-created-c7765cfcd0774f0b96d9ecb415cc4b55

### Reviewer Checklist

- [x] PR has a clear title and description
- [ ] Manually tested the changes that the PR introduces
- [ ] Changes introduced by the PR are covered by tests of acceptable quality
- [x] Checked the quality of [commit messages](http://chris.beams.io/posts/git-commit/)

