### PR TITLE
Adds specialist guild topic followables

### DIFF
--- a/app/jobs/guild_add_followables_job.rb
+++ b/app/jobs/guild_add_followables_job.rb
@@ -1,0 +1,7 @@
+class GuildAddFollowablesJob < ApplicationJob
+  def perform(specialist_id)
+    s = Specialist.find(specialist_id)
+    topicable = s.skills + s.previous_projects.flat_map { |pp| pp.industries + pp.skills } + [s.country]
+    Guild::Topic.where(topicable: topicable.compact).each { |topic| s.follow(topic) }
+  end
+end

--- a/app/models/concerns/guild/specialists_concern.rb
+++ b/app/models/concerns/guild/specialists_concern.rb
@@ -60,32 +60,6 @@ module Guild
         guild_activity.first.created_at > guild_notifications_last_read
       end
 
-      def guild_add_topic_followables!
-        # Skills
-        skills.each do |skill|
-          next unless skill.guild_topic
-
-          follow(skill.guild_topic)
-        end
-
-        # Previous Project industries and skills
-        previous_projects.each do |pp|
-          pp.industries.each do |pp_industry|
-            next unless pp_industry.guild_topic
-
-            follow(pp_industry.guild_topic)
-          end
-          pp.skills.each do |pp_skill|
-            next unless pp_skill.guild_topic
-
-            follow(pp_skill.guild_topic)
-          end
-        end
-
-        # Location
-        follow(country.guild_topic) if country&.guild_topic
-      end
-
       def guild_activity
         @guild_activity ||= [
           guild_post_comments.limit(10),
@@ -123,7 +97,7 @@ module Guild
 
       def guild_joined_callbacks
         self.guild_joined_date ||= Time.current
-        guild_add_topic_followables!
+        GuildAddFollowablesJob.perform_later(id)
       end
     end
   end

--- a/lib/tasks/guild_specialist_followables.rake
+++ b/lib/tasks/guild_specialist_followables.rake
@@ -1,6 +1,8 @@
 namespace :guild do
   task add_all_specialists_topic_followables: :environment do
     desc "Adds guild topic followables for *all* guild specialists"
-    Specialist.guild.find_each(&:guild_add_topic_followables!)
+    Specialist.guild.find_each do |spe|
+      GuildAddFollowablesJob.perform_later(spe.id)
+    end
   end
 end

--- a/spec/jobs/guild_add_followables_job_spec.rb
+++ b/spec/jobs/guild_add_followables_job_spec.rb
@@ -1,0 +1,20 @@
+require "rails_helper"
+
+RSpec.describe GuildAddFollowablesJob do
+  subject(:enqueued_job) {
+    described_class.perform_now(specialist.id)
+  }
+
+  let(:skill) { create(:skill, name: 'Marketing') }
+  let(:specialist) { create(:specialist, skills: [skill]) }
+
+  it "creates guild topic followables for the specialist" do
+    guild_topic = create(:guild_topic, topicable: skill, name: skill.name)
+
+    expect {
+      enqueued_job
+      specialist.reload
+    }.to change { specialist.follows.count }.from(0).to(1)
+    expect(specialist.follows.first.followable).to eq(guild_topic)
+  end
+end


### PR DESCRIPTION
* Need a way to populate the guild topics that specialists should follow for current and future guild specialists.

### Reviewer Checklist

- [ ] PR has a clear title and description
- [ ] Manually tested the changes that the PR introduces
- [ ] Changes introduced by the PR are covered by tests of acceptable quality
- [ ] Checked the quality of [commit messages](http://chris.beams.io/posts/git-commit/)
