### PR TITLE
Add image gallery component to previous project details modal

### DIFF
--- a/app/javascript/src/components/ImageGallery/index.js
+++ b/app/javascript/src/components/ImageGallery/index.js
@@ -1,0 +1,143 @@
+import React, { useState, useEffect, useCallback } from "react";
+import { ChevronBack, ChevronForward } from "@styled-icons/ionicons-outline";
+import { useDialogState, Dialog } from "reakit/Dialog";
+import { rgba } from "polished";
+import styled from "styled-components";
+import { Close } from "@styled-icons/ionicons-outline";
+import { theme, Box, Button, Text } from "@advisable/donut";
+
+export function useImageGallery(opts) {
+  const [index, setIndex] = useState(0);
+  const dialog = useDialogState(opts);
+
+  const handleNext = () => {
+    setIndex(index + 1);
+  };
+
+  const handlePrevious = () => {
+    setIndex(index - 1);
+  };
+
+  const handleOpen = (i) => {
+    setIndex(i);
+    dialog.show();
+  };
+
+  return {
+    ...dialog,
+    next: handleNext,
+    back: handlePrevious,
+    open: handleOpen,
+    index,
+  };
+}
+
+const StyledViewableImageDialog = styled(Dialog).withConfig({
+  shouldForwardProp: (prop) =>
+    !["open", "next", "back", "index"].includes(prop),
+})`
+  top: 0;
+  left: 0;
+  right: 0;
+  bottom: 0;
+  z-index: 10;
+  display: flex;
+  position: fixed;
+  align-items: center;
+  justify-content: center;
+  background: ${rgba(theme.colors.neutral50, 0.9)};
+`;
+
+const StyledGalleryNavigation = styled(Box)`
+  top: 50%;
+  width: 52px;
+  height: 52px;
+  position: absolute;
+  border-radius: 50%;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  transform: translateY(-26px);
+  left: ${(p) => p.left};
+  right: ${(p) => p.right};
+  background: white;
+  cursor: pointer;
+  border: 1px solid ${theme.colors.neutral300};
+
+  &:hover {
+    background-color: ${theme.colors.neutral100};
+  }
+
+  svg {
+    width: 24px;
+  }
+`;
+
+const StyledGalleryImage = styled.img`
+  width: 90%;
+  height: 80%;
+  user-select: none;
+  object-fit: contain;
+`;
+
+const ARROW_RIGHT = 39;
+const ARROW_LEFT = 37;
+
+export default function Viewableimage({ dialog, images }) {
+  const currentImage = images[dialog.index];
+
+  const hasPrevious = dialog.index > 0;
+  const hasNext = dialog.index !== images.length - 1;
+
+  const handleKeyPress = useCallback(
+    (e) => {
+      if (e.keyCode === ARROW_RIGHT && hasNext) {
+        dialog.next();
+      }
+
+      if (e.keyCode === ARROW_LEFT && hasPrevious) {
+        dialog.back();
+      }
+    },
+    [dialog, hasNext, hasPrevious],
+  );
+
+  useEffect(() => {
+    if (dialog.visible) {
+      document.addEventListener("keydown", handleKeyPress);
+      return () => document.removeEventListener("keydown", handleKeyPress);
+    }
+  }, [dialog.visible, handleKeyPress]);
+
+  return (
+    <StyledViewableImageDialog {...dialog} aria-label="Images">
+      <Box position="absolute" zIndex={2} right="16px" top="16px">
+        <Button
+          prefix={<Close />}
+          type="button"
+          variant="dark"
+          size="s"
+          onClick={dialog.hide}
+        >
+          Close
+        </Button>
+      </Box>
+      <Box position="absolute" zIndex={1} top="24px" width="100%">
+        <Text fontSize="l" textAlign="center" color="neutral700">
+          {dialog.index + 1} / {images.length}
+        </Text>
+      </Box>
+      {hasPrevious ? (
+        <StyledGalleryNavigation onClick={dialog.back} left="24px">
+          <ChevronBack />
+        </StyledGalleryNavigation>
+      ) : null}
+      {hasNext ? (
+        <StyledGalleryNavigation onClick={dialog.next} right="24px">
+          <ChevronForward />
+        </StyledGalleryNavigation>
+      ) : null}
+      <StyledGalleryImage src={currentImage.url} />
+    </StyledViewableImageDialog>
+  );
+}

--- a/app/javascript/src/components/PreviousProjectDetails/getProject.js
+++ b/app/javascript/src/components/PreviousProjectDetails/getProject.js
@@ -11,6 +11,11 @@ const getProject = gql`
         name
         color
       }
+      images {
+        id
+        url
+        cover
+      }
       skills {
         id
         name

--- a/app/javascript/src/components/PreviousProjectDetails/index.js
+++ b/app/javascript/src/components/PreviousProjectDetails/index.js
@@ -3,20 +3,27 @@ import { useQuery } from "@apollo/client";
 import { Modal, Avatar, Box, Text, Tag, Paragraph } from "@advisable/donut";
 import GET_PROJECT from "./getProject";
 import IndustryTag from "../IndustryTag";
+import ImageGallery, { useImageGallery } from "components/ImageGallery";
 import renderLineBreaks from "../../utilities/renderLineBreaks";
 import Review from "components/Review";
 import ProjectDetailsLoading from "./ProjectDetailsLoading";
+import { StyledImageThumbnail } from "./styles";
 
 function PreviousProjectDetails({ id }) {
-  const { loading, data } = useQuery(GET_PROJECT, {
+  const gallery = useImageGallery();
+  const { loading, data, error } = useQuery(GET_PROJECT, {
     variables: {
       id: id,
     },
   });
 
   if (loading) return <ProjectDetailsLoading />;
+  if (error) return <Text>Failed to load project, please try again.</Text>;
 
   const project = data.previousProject;
+
+  const cover = project.images.find((i) => i.cover);
+  const otherImages = project.images.filter((i) => !i.cover);
 
   return (
     <>
@@ -35,6 +42,34 @@ function PreviousProjectDetails({ id }) {
           {project.title}
         </Text>
       </Box>
+      {cover ? (
+        <Box mb="6">
+          <ImageGallery dialog={gallery} images={project.images} />
+          <StyledImageThumbnail
+            height="350px"
+            marginBottom="2"
+            onClick={() => gallery.open(0)}
+            style={{ backgroundImage: `url("${cover.url}")` }}
+          />
+          {otherImages.length > 0 ? (
+            <Box
+              display="grid"
+              gridTemplateColumns="1fr 1fr 1fr 1fr 1fr"
+              gridGap="8px"
+            >
+              {otherImages.map((i, index) => (
+                <StyledImageThumbnail
+                  key={i.id}
+                  height="100px"
+                  max-width="140px"
+                  onClick={() => gallery.open(index)}
+                  style={{ backgroundImage: `url("${i.url}")` }}
+                />
+              ))}
+            </Box>
+          ) : null}
+        </Box>
+      ) : null}
       <Box height={1} bg="neutral100" mb="m" />
       <Box mb="m" display="flex" alignItems="center">
         <Box flexShrink={0} mr="s">

--- a/app/javascript/src/components/PreviousProjectDetails/styles.js
+++ b/app/javascript/src/components/PreviousProjectDetails/styles.js
@@ -1,0 +1,18 @@
+import styled from "styled-components";
+import { layout, space } from "styled-system";
+import { theme } from "@advisable/donut";
+
+export const StyledImageThumbnail = styled.div`
+  ${layout};
+  ${space}
+
+  cursor: pointer;
+  border-radius: 12px;
+  background-size: cover;
+  background-position: center;
+  background-color: ${theme.colors.neutral100};
+
+  &:hover {
+    filter: brightness(90%);
+  }
+`;

--- a/app/javascript/src/views/FreelancerProfile/PreviousProjects/ProjectCard/index.js
+++ b/app/javascript/src/views/FreelancerProfile/PreviousProjects/ProjectCard/index.js
@@ -58,8 +58,8 @@ function Project({ project }) {
   return (
     <>
       <ActionBarModal
+        width={800}
         leftIndent={0}
-        width={700}
         dialog={dialog}
         label={project.title}
       >


### PR DESCRIPTION
### Description

We currently don't actually show previous project images anywhere other than on the project card. Now that the new profiles have been released I think it makes sense to add these in. All images will now be shown in the project details view and the user can click into each image to see it at full size.

### Manual Testing Instructions

Steps:
1. Add a project with a few images.
2. Manually verify that project via the console. `PreviousProject.last.update validation_status: "Validated"`
3. View the project on your profile.

### Reviewer Checklist

- [x] PR has a clear title and description
- [x] Manually tested the changes that the PR introduces
- [x] Changes introduced by the PR are covered by tests of acceptable quality
- [x] Checked the quality of [commit messages](http://chris.beams.io/posts/git-commit/)

### Screenshots

![Screenshot 2020-11-23 at 08 15 37](https://user-images.githubusercontent.com/1512593/99940610-689c8600-2d64-11eb-80c9-348fc96bba9f.png)
![Screenshot 2020-11-23 at 08 15 43](https://user-images.githubusercontent.com/1512593/99940612-69cdb300-2d64-11eb-9833-3bccf8b7b6c6.png)
