### PR TITLE
Guild composer nav link disabled fixes

### DIFF
--- a/app/javascript/guild/components/ComposerModal/NavigationMenu.js
+++ b/app/javascript/guild/components/ComposerModal/NavigationMenu.js
@@ -37,6 +37,7 @@ const SetupMenu = React.memo(function SetupMenu({ guildPost, urlPrefix }) {
       <MultistepMenu.Item
         to={`${urlPrefix}/type`}
         isComplete={Boolean(guildPost)}
+        isDisabled={!guildPost}
       >
         Post Type
       </MultistepMenu.Item>
@@ -44,6 +45,7 @@ const SetupMenu = React.memo(function SetupMenu({ guildPost, urlPrefix }) {
       <MultistepMenu.Item
         to={pathWithState(`${urlPrefix}/post`)}
         isComplete={yourPostComplete}
+        isDisabled={!guildPost}
       >
         Your Post
       </MultistepMenu.Item>


### PR DESCRIPTION
* https://www.notion.so/Composer-nav-menu-links-should-not-be-clickable-for-a-new-post-7fbf3ac680364a1eaa668187279c0ecb

### Reviewer Checklist

- [ ] PR has a clear title and description
- [ ] Manually tested the changes that the PR introduces
- [ ] Changes introduced by the PR are covered by tests of acceptable quality
- [ ] Checked the quality of [commit messages](http://chris.beams.io/posts/git-commit/)


