### PR TITLE
Make confirmAccount mutation idempotent

### DIFF
--- a/app/graphql/mutations/confirm_account.rb
+++ b/app/graphql/mutations/confirm_account.rb
@@ -7,9 +7,12 @@ class Mutations::ConfirmAccount < Mutations::BaseMutation
 
   def resolve(email:, token:)
     account = Account.find_by!(email: email)
-    ApiError.invalid_request(code: 'ALREADY_CONFIRMED') if account.confirmed_at.present?
     validate_token(account, token)
-    account.confirmed_at = Time.zone.now
+
+    if account.confirmed_at.blank?
+      account.confirmed_at = Time.zone.now
+    end
+
     account.confirmation_digest = nil
     account.confirmation_token = nil
     Logidze.with_responsible(account.id) do

--- a/app/javascript/src/components/Notifications/index.js
+++ b/app/javascript/src/components/Notifications/index.js
@@ -1,4 +1,4 @@
-import React from "react";
+import React, { useCallback } from "react";
 import { uniqueId } from "lodash-es";
 import { AnimatePresence, motion } from "framer-motion";
 import { Container } from "./styles";
@@ -17,23 +17,29 @@ export const NotificationsProvider = ({ children }) => {
     [setQueue],
   );
 
-  const notify = (content, opts = {}) => {
-    const id = uniqueId("notification");
-    const timeout = opts.timeout || 3000;
-    const variant = opts.variant;
-    const onTimeout = () => remove(id);
-    setQueue((items) => [
-      ...items,
-      { id, variant, content, timeout, onTimeout },
-    ]);
-  };
+  const notify = useCallback(
+    (content, opts = {}) => {
+      const id = uniqueId("notification");
+      const timeout = opts.timeout || 3000;
+      const variant = opts.variant;
+      const onTimeout = () => remove(id);
+      setQueue((items) => [
+        ...items,
+        { id, variant, content, timeout, onTimeout },
+      ]);
+    },
+    [remove],
+  );
 
-  const error = (content, opts = {}) => {
-    notify(content, {
-      variant: "error",
-      ...opts,
-    });
-  };
+  const error = useCallback(
+    (content, opts = {}) => {
+      notify(content, {
+        variant: "error",
+        ...opts,
+      });
+    },
+    [notify],
+  );
 
   const variants = {
     initial: {

--- a/app/javascript/src/views/ConfirmAccount/index.js
+++ b/app/javascript/src/views/ConfirmAccount/index.js
@@ -9,7 +9,7 @@ import CONFIRM_ACCOUNT from "./confirmAccount.graphql";
 const ConfirmAccount = ({ match, location, history }) => {
   const client = useApolloClient();
   const [mutate] = useMutation(CONFIRM_ACCOUNT);
-  const notifications = useNotifications();
+  const { notify } = useNotifications();
   const parsed = queryString.parse(location.search);
 
   const confirmAccount = useCallback(async () => {
@@ -19,26 +19,21 @@ const ConfirmAccount = ({ match, location, history }) => {
 
     const errorCode = errors?.[0]?.extensions?.code;
 
-    if (errorCode === "ALREADY_CONFIRMED") {
-      notifications.notify("Your account has already been confirmed");
-    }
-
     if (errorCode === "INVALID_CONFIRMATION_TOKEN") {
-      notifications.notify("Failed to confirm your account, please try again.");
+      notify("Failed to confirm your account, please try again.");
     }
 
     if (!errorCode) {
-      notifications.notify("Your account has been confirmed");
+      notify("Your account has been confirmed");
     }
 
     await client.resetStore();
     history.replace("/");
-  }, []);
+  }, [notify, client, mutate, history, parsed.email, match.params.token]);
 
   useEffect(() => {
-    if (!parsed.email) return;
     confirmAccount();
-  }, [parsed.email, confirmAccount]);
+  }, [confirmAccount]);
 
   if (!parsed.email) {
     return <Redirect to="/" />;

--- a/app/javascript/src/views/FreelancerSignup/Confirm/ConfirmAccount.js
+++ b/app/javascript/src/views/FreelancerSignup/Confirm/ConfirmAccount.js
@@ -19,7 +19,7 @@ export const CONFIRM = gql`
 
 // Renders the freelancer signup flow.
 const ConfirmAccount = ({ token, email, history }) => {
-  const notifications = useNotifications();
+  const { notify } = useNotifications();
 
   const [confirm] = useMutation(CONFIRM, {
     update(cache, response) {
@@ -39,7 +39,7 @@ const ConfirmAccount = ({ token, email, history }) => {
   });
 
   const confirmAccount = useCallback(async () => {
-    const { errors, data } = await confirm({
+    const { errors } = await confirm({
       variables: {
         input: {
           token,
@@ -49,13 +49,12 @@ const ConfirmAccount = ({ token, email, history }) => {
     });
 
     if (errors) {
-      notifications.notify("Failed to confirm your account. Please try again.");
+      notify("Failed to confirm your account. Please try again.");
       history.replace("/freelancers/signup/confirm");
     } else {
-      window.localStorage.setItem("authToken", data.confirmAccount.token);
       window.location = "/freelancers/signup/preferences";
     }
-  }, [confirm, email, token, history, notifications]);
+  }, [confirm, email, token, history, notify]);
 
   React.useEffect(() => {
     confirmAccount();


### PR DESCRIPTION
Resolves:
 - [Sentry Error](https://sentry.io/organizations/advisable/issues/2042683975/?project=2019647&query=&statsPeriod=14d)
 - [Sentry Error](https://sentry.io/organizations/advisable/issues/2042683973/?project=2019647&query=&statsPeriod=14d)
 - [Sentry Error](https://sentry.io/organizations/advisable/issues/2042683972/?project=2019647&query=&statsPeriod=14d)
 - [Sentry Error](https://sentry.io/organizations/advisable/issues/2039066504/?project=2019647&query=&statsPeriod=14d)

During the freelancer signup flow user’s are asked to confirm their account via email. We validate the confirmation token, confirm the account and then authenticate the user. This is the same account confirmation mutation that is used when clients are asked to confirm their accounts.

Some times users can do weird things. We have had some cases where users either drop off and return via the confirmation link in their emails, or attempt to confirm their account multiple times.

Due to the fact that we check if the account has already been confirmed first before validating the token, users that return to the signup flow via this link will be left in a looping state where the API will return an ALREADY_CONFIRMED code but will not authenticate them.

I don’t think it really makes sense to return an error if the account is already confirmed. Why not just make this request idempotent and return a success if it’s already been confirmed but leave the confirmed_at value as is.

### Reviewer Checklist

- [x] PR has a clear title and description
- [ ] Manually tested the changes that the PR introduces
- [x] Changes introduced by the PR are covered by tests of acceptable quality
- [x] Checked the quality of [commit messages](http://chris.beams.io/posts/git-commit/)