### PR TITLE
Improve Apollo cache management when adding a removing tasks.

### DIFF
--- a/app/javascript/src/views/Booking/Booking.js
+++ b/app/javascript/src/views/Booking/Booking.js
@@ -9,13 +9,13 @@ import {
   useHistory,
 } from "react-router-dom";
 import NotFound from "../NotFound";
-import Layout from "../../components/Layout";
-import TaskDrawer from "../../components/TaskDrawer";
-import useViewer from "../../hooks/useViewer";
+import Layout from "components/Layout";
+import TaskDrawer from "components/TaskDrawer";
+import useViewer from "src/hooks/useViewer";
 import Tasks from "./Tasks";
 import Sidebar from "./Sidebar";
+import FlexibleTutorial from "components/Tutorial/FlexibleProjectTutorial";
 import StoppedWorkingNotice from "./StoppedWorkingNotice";
-import FlexibleTutorial from "../../components/Tutorial/FlexibleProjectTutorial";
 import TASK_FIELDS from "../../graphql/fragments/task";
 
 export default function Booking({ data, match }) {

--- a/app/javascript/src/views/FreelancerActiveApplication/ActiveApplication.js
+++ b/app/javascript/src/views/FreelancerActiveApplication/ActiveApplication.js
@@ -4,15 +4,15 @@ import React from "react";
 import { get } from "lodash-es";
 import { Box, Modal, useModal } from "@advisable/donut";
 import { matchPath, useParams } from "react-router-dom";
-import Layout from "../../components/Layout";
-import TaskDrawer from "../../components/TaskDrawer";
-import FixedTutorial from "../../components/Tutorial/FixedProjectTutorial";
-import FlexibleTutorial from "../../components/Tutorial/FlexibleProjectTutorial";
+import Layout from "components/Layout";
+import TaskDrawer from "components/TaskDrawer";
+import FixedTutorial from "components/Tutorial/FixedProjectTutorial";
+import FlexibleTutorial from "components/Tutorial/FlexibleProjectTutorial";
 import Sidebar from "./Sidebar";
 import Tasks from "./Tasks";
 import SetupPayments from "./SetupPayments";
 import StoppedWorkingNotice from "./StoppedWorkingNotice";
-import useViewer from "../../hooks/useViewer";
+import useViewer from "src/hooks/useViewer";
 import TASK_FIELDS from "../../graphql/fragments/task";
 
 const tutorials = {

--- a/app/javascript/src/views/Proposal/Tasks.js
+++ b/app/javascript/src/views/Proposal/Tasks.js
@@ -2,12 +2,12 @@ import * as React from "react";
 import { Box, Card, Button } from "@advisable/donut";
 import { useApolloClient } from "@apollo/client";
 import { matchPath } from "react-router";
-import Text from "../../components/Text";
-import Modal from "../../components/Modal";
-import Heading from "../../components/Heading";
-import NewTask from "../../components/NewTask";
-import TaskList from "../../components/TaskList";
-import TaskDrawer from "../../components/TaskDrawer";
+import Text from "components/Text";
+import Modal from "components/Modal";
+import Heading from "components/Heading";
+import NewTask from "components/NewTask";
+import TaskList from "components/TaskList";
+import TaskDrawer from "components/TaskDrawer";
 import TASK_FIELDS from "../../graphql/fragments/task";
 import { hasCompleteTasksStep } from "./validationSchema";
 


### PR DESCRIPTION
Resolves: [Ticket](https://sentry.io/organizations/advisable/issues/1973312237/?project=2019647&query=is%3Aunresolved&statsPeriod=14d)

### Description

We currently have things setup in such a way that we can use airtable_id's and uid's interchangeably in URLs. i.e if an application record with a status of "Working" and an airatble_id of "rec123" and an `uid` or "app_123" then the freelancer can view the tasks for that work at either /clients/rec123 or /clients/app_123.

There was a small bug on this view that prevented freelancers from adding tasks when a URL that used the airtable_id. This is because the frontend was trying to update the Apollo cache based on the query but it expected the cache to have a query based on the application uid always rather than the id that was used in the URL.

This updates the logic for adding tasks to the apollo cache to use the [apollo3 cache.modify](https://www.apollographql.com/docs/react/caching/cache-interaction/#cachemodify) functionality instead. This seems like a better way to handle this kind of stuff.

### Manual Testing Instructions

Steps:
1. Create a working application record. `Application.first.update status: "Working", project_type: "Flexible"`
2. Sync the record to airtable by running `Application.first.sync_to_airtable`
2. Login as the freelancer and make sure you can still add and remove task while using both the /clients/uid and /clients/airtable_id URL's
3. Login as the client and ensure you can add and remove tasks while using both the uid and airatble id in the URL.

### Reviewer Checklist

- [ ] PR has a clear title and description
- [ ] Manually tested the changes that the PR introduces
- [ ] Changes introduced by the PR are covered by tests of acceptable quality
- [ ] Checked the quality of [commit messages](http://chris.beams.io/posts/git-commit/)