### PR TITLE
Fix profile links when in guild context

### DIFF
--- a/app/javascript/src/views/FreelancerProfile/MainProfile/index.js
+++ b/app/javascript/src/views/FreelancerProfile/MainProfile/index.js
@@ -3,8 +3,11 @@ import PreviousProjects from "../PreviousProjects";
 import Testimonials from "../Testimonials";
 import NoProjects from "../NoProjects";
 import CallToActionBox from "../CallToActionBox";
+import useViewer from "src/hooks/useViewer";
 
 export default function MainProfile({ isOwner, data }) {
+  const viewer = useViewer();
+  const viewerIsGuild = viewer?.guild || false;
   const reviews = data.specialist.reviews.filter((r) => r.comment);
   const hasReviews = reviews.length > 0;
 
@@ -17,7 +20,9 @@ export default function MainProfile({ isOwner, data }) {
         <NoProjects data={data} isOwner={isOwner} />
       )}
       {hasReviews && <Testimonials reviews={reviews} />}
-      {!isOwner && <CallToActionBox specialist={data.specialist} />}
+      {!isOwner && !viewerIsGuild && (
+        <CallToActionBox specialist={data.specialist} />
+      )}
     </>
   );
 }

--- a/app/javascript/src/views/FreelancerProfile/PreviousProjects/index.js
+++ b/app/javascript/src/views/FreelancerProfile/PreviousProjects/index.js
@@ -1,5 +1,4 @@
 import React, { useMemo, useReducer } from "react";
-import { useHistory } from "react-router";
 import { every } from "lodash-es";
 import { rgba } from "polished";
 // Utils
@@ -58,7 +57,6 @@ const filterProjects = (state) => (project) => {
 
 function PreviousProjects({ data, isOwner }) {
   const [state, dispatch] = useReducer(reducer, data, init);
-  const history = useHistory();
 
   // Update state actions
   const createAction = useMemo(() => createDispatcher(dispatch), []);
@@ -147,11 +145,13 @@ function PreviousProjects({ data, isOwner }) {
           <SectionHeaderText>Previous Projects</SectionHeaderText>
           {isOwner && (
             <Button
-              variant="minimal"
+              as="a"
+              size="xs"
+              variant="subtle"
               ml="auto"
-              onClick={() => history.push("/settings/references")}
+              href="/settings/references"
             >
-              Edit
+              Edit projects
             </Button>
           )}
         </SectionHeaderWrapper>

--- a/app/javascript/src/views/FreelancerProfile/components/SectionHeader.js
+++ b/app/javascript/src/views/FreelancerProfile/components/SectionHeader.js
@@ -5,10 +5,9 @@ import { rgba } from "polished";
 export function SectionHeaderWrapper({ children, divider, ...props }) {
   return (
     <Box
+      mb={3}
       display="flex"
       alignItems="center"
-      mb="xxs"
-      px="xs"
       pb={divider && "xs"}
       borderStyle="solid"
       borderBottomWidth={divider && "1px"}


### PR DESCRIPTION
Resolves: [Loom](https://www.loom.com/share/e1fee4aa598f4071bfd9a6dd3a03fefe)

### Description

When a user has switched to guild and is viewing a users profile or their own profile, we maintain the guild context. Which means we are using guilds routes and not the main apps routes. Eventually we can build the project management into the profile itself but until now we just hard link to the settings to switch them out of guild.

### Reviewer Checklist

- [ ] PR has a clear title and description
- [ ] Manually tested the changes that the PR introduces
- [ ] Changes introduced by the PR are covered by tests of acceptable quality
- [ ] Checked the quality of [commit messages](http://chris.beams.io/posts/git-commit/)