### PR TITLE
Prevent mail encoding error when parsing inbound email

### DIFF
--- a/app/mailboxes/guild_chat_replies_mailbox.rb
+++ b/app/mailboxes/guild_chat_replies_mailbox.rb
@@ -27,7 +27,7 @@ class GuildChatRepliesMailbox < ApplicationMailbox
 
   def mail_body(mail)
     if mail.parts.present?
-      mail.parts.first.body.decoded
+      mail.parts.first.decoded
     else
       mail.decoded
     end


### PR DESCRIPTION
Resolves: [Sentry Error](https://sentry.io/organizations/advisable/issues/2071970592/?project=2021209&query=is%3Aunresolved&statsPeriod=14d)

### Description

We should be calling `.decoded` on the part not the body.

https://github.com/mikel/mail/issues/809#issuecomment-301986573

### Reviewer Checklist

- [ ] PR has a clear title and description
- [ ] Manually tested the changes that the PR introduces
- [ ] Changes introduced by the PR are covered by tests of acceptable quality
- [ ] Checked the quality of [commit messages](http://chris.beams.io/posts/git-commit/)