### PR TITLE
Shadow ban removed guild posts

### DIFF
--- a/app/graphql/mutations/guild/update_guild_post.rb
+++ b/app/graphql/mutations/guild/update_guild_post.rb
@@ -29,8 +29,9 @@ class Mutations::Guild::UpdateGuildPost < Mutations::BaseMutation
       guild_post.guild_topic_list = guild_topics
     end
 
-    if args[:publish].present?
-      guild_post.status = args[:publish] ? "published" : "draft"
+    # - A removed post cannot be published
+    if args[:publish].present? && guild_post.status != "removed"
+      guild_post.status = "published"
     end
 
     guild_post.save!

--- a/app/graphql/types/query_type.rb
+++ b/app/graphql/types/query_type.rb
@@ -272,10 +272,7 @@ class Types::QueryType < Types::BaseType
 
   def guild_posts(**args)
     requires_guild_user!
-    @query = Guild::Post.includes(
-      :specialist,
-      parent_comments: [child_comments: %i[post]]
-    ).published
+    @query = Guild::Post.feed(current_user)
 
     if (type = args[:type].presence) && type != 'For You'
       @query = @query.where(type: type)
@@ -327,6 +324,6 @@ class Types::QueryType < Types::BaseType
 
   def guild_your_posts(**args)
     requires_guild_user!
-    current_user.guild_your_posts.order(updated_at: :desc)
+    current_user.guild_posts.order(updated_at: :desc)
   end
 end

--- a/app/graphql/types/specialist_type.rb
+++ b/app/graphql/types/specialist_type.rb
@@ -197,7 +197,7 @@ class Types::SpecialistType < Types::BaseType
 
   field :guild_posts, Types::Guild::PostInterface.connection_type, null: false
   def guild_posts
-    object.guild_posts.published.order(created_at: :desc)
+    object.guild_posts.feed(current_user)
   end
 
   field :guild_joined_time_ago, String, null: true do

--- a/app/javascript/guild/views/YourPosts/index.js
+++ b/app/javascript/guild/views/YourPosts/index.js
@@ -40,16 +40,19 @@ const YourPosts = () => {
       <GuildBox spaceChildrenVertical={48}>
         <Filters yourPosts />
         {data &&
-          data.guildYourPosts.nodes.map((post, key) => (
-            <Box key={key} position="relative">
-              <StyledStatus onClick={() => handleEdit(post.id)}>
-                {post.status === "draft" ? "Edit Draft" : "Edit"}
-              </StyledStatus>
-              <StyledYourPost draft={post.status === "draft"}>
-                <Post post={post} showDelete={true} />
-              </StyledYourPost>
-            </Box>
-          ))}
+          data.guildYourPosts.nodes.map((post, key) => {
+            const published = /published|removed/.test(post.status);
+            return (
+              <Box key={key} position="relative">
+                <StyledStatus onClick={() => handleEdit(post.id)}>
+                  {published ? "Edit" : "Edit Draft"}
+                </StyledStatus>
+                <StyledYourPost draft={!published}>
+                  <Post post={post} />
+                </StyledYourPost>
+              </Box>
+            );
+          })}
         {!loading && !data?.guildYourPosts?.nodes?.length && (
           <GuildBox
             background="white"

--- a/app/models/concerns/guild/specialists_concern.rb
+++ b/app/models/concerns/guild/specialists_concern.rb
@@ -33,10 +33,6 @@ module Guild::SpecialistsConcern
                    guild_calendly_link: [:string],
                    guild_featured_member_at: :datetime
 
-    def guild_your_posts
-      guild_posts.where(status: %w[published draft])
-    end
-
     def touch_guild_notifications_last_read
       update!(guild_notifications_last_read: Time.current)
     end

--- a/app/models/guild/post.rb
+++ b/app/models/guild/post.rb
@@ -28,6 +28,13 @@ module Guild
     has_many :engagements,
              class_name: 'Guild::PostEngagement', foreign_key: 'guild_post_id', dependent: :destroy, inverse_of: 'post'
 
+    scope :feed, lambda { |specialist|
+      published.
+        or(removed.where(specialist: specialist)).
+        includes(:specialist).
+        order(created_at: :desc)
+    }
+
     enum status: {draft: 0, published: 1, removed: 2}
 
     validates :type, :status, presence: true


### PR DESCRIPTION
Shadow ban for removed guild posts

Behavior:

1.  Removed posts are not included in the feed or on the specialist's profile guild section
2. Removed posts are included in the above if the viewer is the author
3. A removed post will show up in 'Your Posts' as a published post.  Any subsequent edits will not change the removed status though.

### Reviewer Checklist

- [ ] PR has a clear title and description
- [ ] Manually tested the changes that the PR introduces
- [ ] Changes introduced by the PR are covered by tests of acceptable quality
- [ ] Checked the quality of [commit messages](http://chris.beams.io/posts/git-commit/)
