### PR TITLE
Add Zappier action for creating magic links

### DIFF
--- a/app/controllers/zappier_interactor_controller.rb
+++ b/app/controllers/zappier_interactor_controller.rb
@@ -1,4 +1,6 @@
 class ZappierInteractorController < ApplicationController
+  include MagicLinkHelper
+
   skip_before_action :verify_authenticity_token
   before_action :verify_key!
 
@@ -12,7 +14,32 @@ class ZappierInteractorController < ApplicationController
     render json: {error: "No image attached."}, status: :unprocessable_entity
   end
 
+  def create_magic_link
+    account = find_account_from_uid(params[:uid])
+    url = params[:url]
+    options = {}
+    options[:expires_at] = params[:expires_at] if params[:expires_at].present?
+    link = magic_link(account, url, **options)
+    render json: {magic_link: link}
+  rescue ActiveRecord::RecordNotFound
+    render json: {error: "Account not found"}, status: :unprocessable_entity
+  end
+
   private
+
+  def find_account_from_uid(uid)
+    klass = case uid
+            when /^spe/
+              Specialist
+            when /^use/
+              User
+            when /^acc/
+              return Account.find_by!(uid: uid)
+            else
+              raise ActiveRecord::RecordNotFound
+            end
+    klass.public_send(:find_by!, uid: uid).account
+  end
 
   def verify_key!
     return if params[:key].present? && params[:key] == ENV["ACCOUNTS_CREATE_KEY"]

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -62,10 +62,11 @@ Rails.application.routes.draw do
   post '/projects/send_invites'
   post '/projects/create_linkedin_ad'
 
-  get '/accounts/me'
-  post '/accounts/user'
-  post '/accounts/specialist'
+  get 'accounts/me'
+  post 'accounts/user'
+  post 'accounts/specialist'
   post 'zappier_interactor/attach_previous_project_image'
+  post 'zappier_interactor/create_magic_link'
 
   # match every other route to the frontend codebase
   root 'application#frontend'

--- a/spec/controllers/zappier_interactor_controller_spec.rb
+++ b/spec/controllers/zappier_interactor_controller_spec.rb
@@ -1,10 +1,11 @@
 require "rails_helper"
 
 RSpec.describe ZappierInteractorController, type: :request do
+  let(:key) { ENV["ACCOUNTS_CREATE_KEY"] }
+
   describe "POST /attach_previous_project_image" do
     let(:previous_project) { create(:previous_project) }
     let(:image) { "http://path.to/image.jpg" }
-    let(:key) { ENV["ACCOUNTS_CREATE_KEY"] }
     let(:params) { {uid: previous_project.uid, image_url: image, key: key} }
 
     it "enqueues the job" do
@@ -13,7 +14,7 @@ RSpec.describe ZappierInteractorController, type: :request do
       expect(AttachImageJob).to have_been_enqueued.with(previous_project, image)
     end
 
-    context "no key" do
+    context "when no key" do
       let(:key) { '' }
 
       it "is unauthorized" do
@@ -23,7 +24,7 @@ RSpec.describe ZappierInteractorController, type: :request do
       end
     end
 
-    context "no image" do
+    context "when no image" do
       let(:image) { nil }
 
       it "is unprocessable" do
@@ -33,12 +34,73 @@ RSpec.describe ZappierInteractorController, type: :request do
       end
     end
 
-    context "non-existing project" do
+    context "when non-existing project" do
       it "is unprocessable" do
         params[:uid] = 'pre_does_not_exist'
         post("/zappier_interactor/attach_previous_project_image", params: params)
         expect(response).to have_http_status(:unprocessable_entity)
         expect(AttachImageJob).not_to have_been_enqueued.with(previous_project, image)
+      end
+    end
+  end
+
+  describe "POST /create_magic_link" do
+    let(:url) { "http://path.to/image.jpg" }
+    let(:user) { create(:specialist) }
+    let(:params) { {uid: user.uid, url: url, key: key} }
+
+    context "when no key" do
+      let(:key) { '' }
+
+      it "is unauthorized" do
+        post("/zappier_interactor/create_magic_link", params: params)
+        expect(response).to have_http_status(:unauthorized)
+      end
+    end
+
+    context "when specialist" do
+      it "creates a magic link" do
+        post("/zappier_interactor/create_magic_link", params: params)
+        expect(response).to have_http_status(:success)
+        link = JSON[response.body]["magic_link"]
+        expect(link).to include("&mluid=#{user.account.uid}")
+      end
+    end
+
+    context "when user" do
+      let(:user) { create(:user) }
+
+      it "creates a magic link" do
+        post("/zappier_interactor/create_magic_link", params: params)
+        expect(response).to have_http_status(:success)
+        link = JSON[response.body]["magic_link"]
+        expect(link).to include("&mluid=#{user.account.uid}")
+      end
+    end
+
+    context "when account" do
+      let(:user) { create(:account) }
+
+      it "creates a magic link" do
+        post("/zappier_interactor/create_magic_link", params: params)
+        expect(response).to have_http_status(:success)
+        link = JSON[response.body]["magic_link"]
+        expect(link).to include("&mluid=#{user.uid}")
+      end
+    end
+
+    context "when provided expires_at" do
+      let(:expires_at) { 1.month.from_now }
+
+      it "creates a magic link" do
+        post("/zappier_interactor/create_magic_link", params: params.merge(expires_at: expires_at))
+        expect(response).to have_http_status(:success)
+        link = JSON[response.body]["magic_link"]
+        params = CGI.parse(URI.parse(link).query)
+        magic = user.account.magic_links.where(path: "/image.jpg").find do |ml|
+          ml.valid_token(params["mlt"].first)
+        end
+        expect(magic.expires_at.to_i).to eq(expires_at.to_i)
       end
     end
   end


### PR DESCRIPTION
Resolves: [Magic Links Via Zapier](https://airtable.com/tblzKtqH2SVFDMJBw/viwbjBqy6YW12N7Rn/reccnAI5djqhHmsIl?blocks=hide)

### Description

Adds an ability to create magic links via zappier actions. `expires_at` is optional

https://developer.zapier.com/app/119254/version/1.0.0/actions/creates/create_magic_link/api

### Manual Testing Instructions

Steps:
1. Set up app locally and create a ngrok tunnel
2. Update the API endpoint in the zap action
3. Test the action

### Reviewer Checklist

- [x] PR has a clear title and description
- [x] Manually tested the changes that the PR introduces
- [x] Changes introduced by the PR are covered by tests of acceptable quality
- [x] Checked the quality of [commit messages](http://chris.beams.io/posts/git-commit/)