### PR TITLE
Adds ability to fetch > 50 messages

### DIFF
--- a/app/javascript/guild/hooks/twilioChat/useTwilioChat.js
+++ b/app/javascript/guild/hooks/twilioChat/useTwilioChat.js
@@ -7,6 +7,7 @@ export const useTwilioChat = ({ channelSid }) => {
     messages: [],
     initializing: false,
     activeChannel: null,
+    fetchingMoreMessages: false,
   });
 
   useEffect(() => {
@@ -45,6 +46,7 @@ export const useTwilioChat = ({ channelSid }) => {
   }, []);
 
   const onLoadPreviousMessages = async () => {
+    setChatState({ ...chatState, fetchingMoreMessages: true });
     const { paginator: old, activeChannel } = chatState;
     const paginator = await old.prevPage();
     await activeChannel.setAllMessagesConsumed();
@@ -53,6 +55,7 @@ export const useTwilioChat = ({ channelSid }) => {
       ...prev,
       paginator,
       messages: [...paginator.items, ...prev.messages],
+      fetchingMoreMessages: false,
     }));
   };
 


### PR DESCRIPTION
* This adds something to allow people to retrieve their older messages if there's more than `50` messages.

@thomascullen https://www.loom.com/share/0ba9dcbad77a4adc997b634bc929639d
Could use your help on the design for this as well ... feels like a button makes sense but maybe we need something else

Behavior:

1. If there's a prev page of messages show a button at the top of the conversation container
2. don't scroll to the bottom w/ a new render if we're only loading previous messages
3. always scroll to the bottom if there is a new message that hasn't been consumed

### Reviewer Checklist

- [ ] PR has a clear title and description
- [ ] Manually tested the changes that the PR introduces
- [ ] Changes introduced by the PR are covered by tests of acceptable quality
- [ ] Checked the quality of [commit messages](http://chris.beams.io/posts/git-commit/)
