### PR TITLE
Remove link to old freelancer search flow from manager empty state

### DIFF
--- a/app/javascript/src/views/ActiveTalent/Empty.js
+++ b/app/javascript/src/views/ActiveTalent/Empty.js
@@ -1,7 +1,6 @@
 // Loads the empty state for the manage talent view
 import React from "react";
-import { Link } from "react-router-dom";
-import { Box, Text, Button } from "@advisable/donut";
+import { Box, Text } from "@advisable/donut";
 import illustration from "./illustration.png";
 
 export default function ActiveTalentEmpty() {
@@ -19,9 +18,6 @@ export default function ActiveTalentEmpty() {
           start a project with a freelancer you will be able to manage their
           work from here.
         </Text>
-        <Link to="/freelancer_search">
-          <Button>Create a project</Button>
-        </Link>
       </div>
     </div>
   );


### PR DESCRIPTION
We had a link to the old freelancer search flow which doesn't exist anymore on the empty state when the client had no active freelancers.

### Reviewer Checklist

- [ ] PR has a clear title and description
- [ ] Manually tested the changes that the PR introduces
- [ ] Changes introduced by the PR are covered by tests of acceptable quality
- [ ] Checked the quality of [commit messages](http://chris.beams.io/posts/git-commit/)

