### PR TITLE
Fix data loading issues in guild messages

### DIFF
--- a/app/javascript/guild/views/Messages/components/ActiveConversation.js
+++ b/app/javascript/guild/views/Messages/components/ActiveConversation.js
@@ -44,7 +44,7 @@ const ActiveConversation = ({ channelSid }) => {
     return Object.values(members).filter((uid) => uid !== viewer.id)?.[0];
   }, [viewer, activeConversation]);
 
-  const { data } = useQuery(CHAT_PARTICIPANT_QUERY, {
+  const { data, loading } = useQuery(CHAT_PARTICIPANT_QUERY, {
     variables: { id: other },
     skip: !other,
   });
@@ -82,7 +82,7 @@ const ActiveConversation = ({ channelSid }) => {
     messagesRef.current.scrollTop = messagesRef.current.scrollTop - 64;
   }
 
-  if (initializing) return <Loading />;
+  if (initializing || loading) return <Loading />;
 
   return (
     activeConversation && (


### PR DESCRIPTION
[sentry error](https://sentry.io/organizations/advisable/issues/2086381192/?project=2019647&query=is%3Aunresolved&statsPeriod=14d)
[sentry error](https://sentry.io/organizations/advisable/issues/2086381192/?project=2019647&query=is%3Aunresolved&statsPeriod=14d)

We weren't waiting for the request  that fetches the participants image and name to complete so would raise errors on slow connections.

### Reviewer Checklist

- [ ] PR has a clear title and description
- [ ] Manually tested the changes that the PR introduces
- [ ] Changes introduced by the PR are covered by tests of acceptable quality
- [ ] Checked the quality of [commit messages](http://chris.beams.io/posts/git-commit/)