### PR TITLE
Also set context[:current_user] on login

### DIFF
--- a/app/graphql/mutations/confirm_account.rb
+++ b/app/graphql/mutations/confirm_account.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 class Mutations::ConfirmAccount < Mutations::BaseMutation
   include Mutations::Helpers::Authentication
   argument :email, String, required: true
@@ -18,6 +20,7 @@ class Mutations::ConfirmAccount < Mutations::BaseMutation
     Logidze.with_responsible(account.id) do
       account.save(validate: false)
     end
+
     login_as(account)
 
     {viewer: account.specialist_or_user}

--- a/app/graphql/mutations/create_freelancer_account.rb
+++ b/app/graphql/mutations/create_freelancer_account.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: false
+
 # Creates a new freelancer account
 class Mutations::CreateFreelancerAccount < Mutations::BaseMutation
   include Mutations::Helpers::Authentication
@@ -95,7 +97,6 @@ class Mutations::CreateFreelancerAccount < Mutations::BaseMutation
       specialist.send_confirmation_email
     end
 
-    context[:current_user] = specialist
     login_as(account)
 
     {viewer: specialist.reload}

--- a/app/graphql/mutations/helpers/authentication.rb
+++ b/app/graphql/mutations/helpers/authentication.rb
@@ -1,13 +1,14 @@
+# frozen_string_literal: true
+
 module Mutations::Helpers::Authentication
+  delegate :logout, to: :session_manager
+
   def session_manager
     context[:session_manager]
   end
 
   def login_as(account)
+    context[:current_user] = account.specialist_or_user
     session_manager.login(account)
-  end
-
-  def logout
-    session_manager.logout
   end
 end

--- a/app/graphql/mutations/login.rb
+++ b/app/graphql/mutations/login.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 class Mutations::Login < Mutations::BaseMutation
   include Mutations::Helpers::Authentication
 
@@ -11,7 +13,6 @@ class Mutations::Login < Mutations::BaseMutation
     no_account_error unless account&.has_password?
     invalid_credentials unless account.authenticate(password)
     login_as(account)
-    context[:current_user] = account.specialist_or_user
     {viewer: account.specialist_or_user}
   end
 


### PR DESCRIPTION
Resolves: 
[Sentry Error](https://sentry.io/organizations/advisable/issues/2042683975/?project=2019647&query=is%3Aunresolved&statsPeriod=14d)
[Sentry Error](https://sentry.io/organizations/advisable/issues/2042683973/?project=2019647&query=is%3Aunresolved&statsPeriod=14d)
[Sentry Error](https://sentry.io/organizations/advisable/issues/2042683972/?project=2019647&query=is%3Aunresolved&statsPeriod=14d)

### Description

The account confirmation was returning errors claiming the current user did not have access to viewer fields. This was because we weren't setting the `context[:current_user]` when logging in and the policies were failing some fields. When the mutation starts, the context[:current_user] is `nil` because they aren't logged in, however, after confirming the account we want to log them in and so we need to change it.

I have done this inside of the `login` method in the `BaseMutation` so that it also applies to other areas where we are doing logins.

### Reviewer Checklist

- [x] PR has a clear title and description
- [ ] Manually tested the changes that the PR introduces
- [x] Changes introduced by the PR are covered by tests of acceptable quality
- [x] Checked the quality of [commit messages](http://chris.beams.io/posts/git-commit/)