### PR TITLE
Also sync the Owner column to Airtable

### DIFF
--- a/app/models/concerns/airtable/client_contact.rb
+++ b/app/models/concerns/airtable/client_contact.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # Class for syncing airtable client contacts to our local users table
 class Airtable::ClientContact < Airtable::Base
   self.table_name = 'Client Contacts'
@@ -87,7 +89,7 @@ class Airtable::ClientContact < Airtable::Base
     self['VAT Number'] = user.account.vat_number # TODO: Read this from Company
     self['Industry'] = [user.company.industry.try(:airtable_id)].compact
     self['Type of Company'] = user.company.kind
-
+    self['Owner'] = [user.sales_person&.airtable_id].compact
     self['PID'] = user.pid
     self['Campaign Name'] = user.campaign_name
     self['Campaign Source'] = user.campaign_source


### PR DESCRIPTION
We weren't syncing the Owner from postgres to airtable for client contacts. Meaning for invited users the Owner in Airtable was always nil and the next time it synced it would overwrite the value in postgres and unset it.

### Reviewer Checklist

- [ ] PR has a clear title and description
- [ ] Manually tested the changes that the PR introduces
- [ ] Changes introduced by the PR are covered by tests of acceptable quality
- [ ] Checked the quality of [commit messages](http://chris.beams.io/posts/git-commit/)