### PR TITLE
Make published, created_at, author attrs searchable in posts admin

### DIFF
--- a/app/dashboards/guild/post_dashboard.rb
+++ b/app/dashboards/guild/post_dashboard.rb
@@ -12,6 +12,10 @@ module Guild
     # on pages throughout the dashboard.
     ATTRIBUTE_TYPES = {
       specialist: SimpleBelongsToField,
+      account: Field::HasOne.with_options(
+        searchable: true,
+        searchable_fields: %w[first_name last_name email]
+      ),
       guild_topics: ActsAsTaggableField,
       # guild_topic_list: Field::String.with_options(searchable: false),
       images: Field::HasMany.with_options(class_name: "Guild::PostImage"),
@@ -37,8 +41,9 @@ module Guild
     # Feel free to add, remove, or rearrange items.
     COLLECTION_ATTRIBUTES = %i[
       title
-      specialist
       status
+      created_at
+      account
     ].freeze
 
     # SHOW_PAGE_ATTRIBUTES
@@ -85,7 +90,9 @@ module Guild
     #   COLLECTION_FILTERS = {
     #     open: ->(resources) { resources.where(open: true) }
     #   }.freeze
-    COLLECTION_FILTERS = {}.freeze
+    COLLECTION_FILTERS = {
+      published: ->(resources) { resources.published }
+    }.freeze
 
     # Overwrite this method to customize how posts are displayed
     # across all pages of the admin dashboard.

--- a/app/models/application_reference.rb
+++ b/app/models/application_reference.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 class ApplicationReference < ApplicationRecord
   include Uid
   uid_prefix 'ref'
@@ -20,9 +22,9 @@ end
 #
 # Indexes
 #
-#  index_application_references_on_application_id  (application_id)
-#  index_application_references_on_project         (project_type,project_id)
-#  index_application_references_on_uid             (uid)
+#  index_application_references_on_application_id               (application_id)
+#  index_application_references_on_project_type_and_project_id  (project_type,project_id)
+#  index_application_references_on_uid                          (uid)
 #
 # Foreign Keys
 #

--- a/app/models/guild/post.rb
+++ b/app/models/guild/post.rb
@@ -10,6 +10,7 @@ module Guild
     AUDIENCE_TYPES = %w[skills industries locations none].freeze
 
     belongs_to :specialist
+    has_one :account, through: :specialist
     has_many :reactions, as: :reactionable, dependent: :destroy
 
     has_many :comments,

--- a/app/models/guild/post/advice_required.rb
+++ b/app/models/guild/post/advice_required.rb
@@ -1,9 +1,11 @@
+# frozen_string_literal: true
+
 module Guild
   class Post::AdviceRequired < Post
     acts_as_ordered_taggable_on :guild_topics
 
     jsonb_accessor :data,
-      need_help: [:boolean, default: true]
+                   need_help: [:boolean, {default: true}]
   end
 end
 

--- a/app/models/guild/post/case_study.rb
+++ b/app/models/guild/post/case_study.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module Guild
   class Post::CaseStudy < Post
     acts_as_ordered_taggable_on :guild_topics

--- a/app/models/guild/post/opportunity.rb
+++ b/app/models/guild/post/opportunity.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module Guild
   class Post::Opportunity < Post
     acts_as_ordered_taggable_on :guild_topics

--- a/app/models/guild/post_engagement.rb
+++ b/app/models/guild/post_engagement.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module Guild
   class PostEngagement < ApplicationRecord
     belongs_to :specialist
@@ -11,11 +13,11 @@ end
 #
 # Table name: guild_post_engagements
 #
-#  id            :bigint           not null, primary key
-#  created_at    :datetime         not null
-#  updated_at    :datetime         not null
-#  guild_post_id :uuid
-#  specialist_id :bigint
+#  id              :bigint           not null, primary key
+#  created_at      :datetime         not null
+#  updated_at      :datetime         not null
+#  guild_post_id   :uuid
+#  specialist_id   :bigint
 #
 # Indexes
 #

--- a/app/models/guild/topic.rb
+++ b/app/models/guild/topic.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module Guild
   # This is a light wrapper for `ActsAsTaggableOn::Tag` so that specialists
   #   can follow guild topics ( tags )

--- a/app/models/project_skill.rb
+++ b/app/models/project_skill.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 class ProjectSkill < ApplicationRecord
   belongs_to :skill, counter_cache: :projects_count
   belongs_to :project, polymorphic: true
@@ -18,8 +20,8 @@ end
 #
 # Indexes
 #
-#  index_project_skills_on_project   (project_type,project_id)
-#  index_project_skills_on_skill_id  (skill_id)
+#  index_project_skills_on_project_type_and_project_id  (project_type,project_id)
+#  index_project_skills_on_skill_id                     (skill_id)
 #
 # Foreign Keys
 #

--- a/app/models/review.rb
+++ b/app/models/review.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # Represents a review of a specialist in various contexts. A review will always
 # have an attached specialist and project.
 # The "reviewable" for a review represent the record that was reviewed. This
@@ -66,10 +68,10 @@ end
 #
 # Indexes
 #
-#  index_reviews_on_airtable_id    (airtable_id)
-#  index_reviews_on_project        (project_type,project_id)
-#  index_reviews_on_reviewable     (reviewable_type,reviewable_id)
-#  index_reviews_on_specialist_id  (specialist_id)
+#  index_reviews_on_airtable_id                        (airtable_id)
+#  index_reviews_on_project_type_and_project_id        (project_type,project_id)
+#  index_reviews_on_reviewable_type_and_reviewable_id  (reviewable_type,reviewable_id)
+#  index_reviews_on_specialist_id                      (specialist_id)
 #
 # Foreign Keys
 #


### PR DESCRIPTION
* Adding some improvements that Annie requested for the posts dashboard

1. search by the author email, name
2. sort created_at
3. adds collection filter to search by, `published` ( can combine author w/ this, e.g., `published: Geoffrey` )

- [x] PR has a clear title and description
- [x] Manually tested the changes that the PR introduces
- [ ] Changes introduced by the PR are covered by tests of acceptable quality
- [x] Checked the quality of [commit messages](http://chris.beams.io/posts/git-commit/)
