### PR TITLE
Fix industry name TypeError in SkillsSummary

### DIFF
--- a/app/javascript/src/views/Project/components/SkillsSummary.js
+++ b/app/javascript/src/views/Project/components/SkillsSummary.js
@@ -6,7 +6,7 @@ export default function GoalsSummary({ project, children }) {
   const { t } = useTranslation();
 
   const { primarySkill, user } = project;
-  const industry = user.industry.name;
+  const industry = user.industry?.name;
   const companyType = user.companyType;
 
   let heading = "Project Skills";


### PR DESCRIPTION
Fix "TypeError: Cannot read property 'name' of null" with optional chaining

Resolves: [Sentry](https://sentry.io/organizations/advisable/issues/2153701487/?environment=production&project=2019647&referrer=alert_email)

### Description

Describe the changes and motivations for the pull request, unless obvious from the title.

### Manual Testing Instructions

Steps:
1.
2.
3.

### Reviewer Checklist

- [ ] PR has a clear title and description
- [ ] Manually tested the changes that the PR introduces
- [ ] Changes introduced by the PR are covered by tests of acceptable quality
- [ ] Checked the quality of [commit messages](http://chris.beams.io/posts/git-commit/)

### Screenshots

![image](https://user-images.githubusercontent.com/849247/104660829-f430f400-56cf-11eb-95c1-732ef0ac65db.png)

### Other

Provide additional notes, remarks, links, mention specific people to review,…
