### PR TITLE
Remove deprecated Booking from WebhookConfiguration

### DIFF
--- a/app/models/webhook_configuration.rb
+++ b/app/models/webhook_configuration.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # DEPRECATED
 # Webhook configurations have been deprecated and you should add a new
 # WebhookEvent instead.
@@ -8,9 +10,7 @@ class WebhookConfiguration < ApplicationRecord
   validate :valid_criteria
   serialize :criteria, Array
 
-  OPERATORS = [
-    "changes_to"
-  ]
+  OPERATORS = ["changes_to"].freeze
 
   # This is a hack to prevent rails path generators from loading for single
   # table inheritance. i.e allways use webhook_configuration_path
@@ -28,8 +28,7 @@ class WebhookConfiguration < ApplicationRecord
     end
     return unless matched_criteria.length == criteria.length
 
-    webhook = Webhook.create(url: url, data: data(entity))
-    webhook
+    Webhook.create(url: url, data: data(entity))
   end
 
   def data(entity)
@@ -45,8 +44,6 @@ class WebhookConfiguration < ApplicationRecord
 
     entity[attribute] =~ Regexp.new(value)
   end
-
-  private
 
   def valid_criteria
     errors.add(:criteria, "must have at least one criteria") if criteria.length.zero?

--- a/app/views/fields/webhook_type_field/_form.html.erb
+++ b/app/views/fields/webhook_type_field/_form.html.erb
@@ -5,8 +5,7 @@
   Which record type does this webhook apply to?
   <%= f.select field.attribute, [
     ["Application", "WebhookConfiguration::Application"],
-    ["Booking", "WebhookConfiguration::Booking"],
     ["Interview", "WebhookConfiguration::Interview"],
     ["Project", "WebhookConfiguration::Project"]
-    ] %>
+  ] %>
 </div>


### PR DESCRIPTION
Resolves: https://sentry.io/organizations/advisable/issues/2160960525/?environment=production&project=2021209&referrer=alert_email

### Description

We nuked `Booking` so this can go as well.

### Reviewer Checklist

- [ ] PR has a clear title and description
- [ ] Manually tested the changes that the PR introduces
- [ ] Changes introduced by the PR are covered by tests of acceptable quality
- [ ] Checked the quality of [commit messages](http://chris.beams.io/posts/git-commit/)