### PR TITLE
Truncates long topic names in sidebar

### DIFF
--- a/app/javascript/guild/components/Topics/components/Topic/index.js
+++ b/app/javascript/guild/components/Topics/components/Topic/index.js
@@ -3,11 +3,14 @@ import { lowerDashed } from "@guild/utils";
 import { Hashtag } from "@styled-icons/heroicons-solid";
 import { StyledTopic } from "./styles";
 import { NavLink } from "react-router-dom";
+import { truncate } from "lodash-es";
 
 const Topic = ({ topic }) => (
   <StyledTopic as={NavLink} to={`/topics/${topic.id}`}>
-    <Hashtag />
-    {lowerDashed(topic.name)}
+    <span>
+      <Hashtag />
+      {truncate(lowerDashed(topic.name), { length: 29 })}
+    </span>
   </StyledTopic>
 );
 


### PR DESCRIPTION
Changes:

* Truncate any long topic names in the sidebar on the guild feed

### Reviewer Checklist

- [ ] PR has a clear title and description
- [ ] Manually tested the changes that the PR introduces
- [ ] Changes introduced by the PR are covered by tests of acceptable quality
- [ ] Checked the quality of [commit messages](http://chris.beams.io/posts/git-commit/)

![Screen Shot 2021-01-18 at 3 27 47 PM](https://user-images.githubusercontent.com/34672/104971217-ecf53900-59a2-11eb-8911-64a02bf42ba1.png)
