### PR TITLE
Allow for cases when post content is null

### DIFF
--- a/app/javascript/guild/components/Markdown/index.js
+++ b/app/javascript/guild/components/Markdown/index.js
@@ -4,7 +4,7 @@ import { StyledMarkdown } from "./styles";
 import urlRegex from "url-regex";
 
 export default function Markdown({ children }) {
-  const formatLinks = (source) => source.replace(urlRegex(), "[$&]($&)");
+  const formatLinks = (source) => source?.replace(urlRegex(), "[$&]($&)");
 
   const renderLinks = ({ href }) => {
     const uri = href.startsWith("http") ? href : `//${href}`;


### PR DESCRIPTION
[Sentry error](https://sentry.io/organizations/advisable/issues/2164333468/?project=2019647&query=is%3Aunresolved&statsPeriod=14d)

Allow for cases when markdown content is null.