### PR TITLE
Split profile fields fragment into two separate fragments

### DIFF
--- a/app/javascript/src/views/FreelancerProfile/queries.js
+++ b/app/javascript/src/views/FreelancerProfile/queries.js
@@ -1,7 +1,7 @@
 import { gql, useQuery } from "@apollo/client";
 import GuildPostFields from "@guild/graphql/fragments/guildPostFields";
 
-const fields = gql`
+const projectFields = gql`
   fragment ProjectFields on PreviousProject {
     id
     title
@@ -38,7 +38,9 @@ const fields = gql`
       companyName
     }
   }
+`;
 
+const specialistFields = gql`
   fragment SpecialistFields on Specialist {
     id
     name
@@ -79,7 +81,9 @@ const fields = gql`
 `;
 
 export const GET_PROFILE = gql`
-  ${fields}
+  ${projectFields}
+  ${specialistFields}
+
   query getProfileData($id: ID!, $isOwner: Boolean!) {
     specialist(id: $id) {
       ...SpecialistFields
@@ -106,7 +110,8 @@ export const GET_COUNTRIES = gql`
 `;
 
 export const UPDATE_PROFILE = gql`
-  ${fields}
+  ${specialistFields}
+
   mutation UpdateProfile($input: UpdateProfileInput!) {
     updateProfile(input: $input) {
       specialist {
@@ -135,7 +140,8 @@ export const updateProfileOptimisticResponse = (specialist, values) => {
 };
 
 export const SET_COVER_PHOTO = gql`
-  ${fields}
+  ${specialistFields}
+
   mutation SetCoverPhoto($input: SetCoverPhotoInput!) {
     setCoverPhoto(input: $input) {
       specialist {


### PR DESCRIPTION
Resolves: [Sentry errors](https://sentry.io/organizations/advisable/issues/2164433820/?project=2019647&query=is%3Aunresolved&statsPeriod=14d)

### Description

GraphQL will raise an error if you define a fragment in a request and don't use it. This mean that the update profile queries are failing.

### Reviewer Checklist

- [ ] PR has a clear title and description
- [ ] Manually tested the changes that the PR introduces
- [ ] Changes introduced by the PR are covered by tests of acceptable quality
- [ ] Checked the quality of [commit messages](http://chris.beams.io/posts/git-commit/)