### PR TITLE
Allow 'Brief Confirmed' as a status when confirming a project

### DIFF
--- a/app/services/projects/confirm.rb
+++ b/app/services/projects/confirm.rb
@@ -3,14 +3,14 @@
 class Projects::Confirm < ApplicationService
   attr_reader :project
 
-  ALLOWED_STATSUES = ["Brief Pending Confirmation", "Brief Confirmed"].freeze
-
   def initialize(project:)
     @project = project
   end
 
   def call
-    unless ALLOWED_STATSUES.include?(project.status)
+    return project if project.status == 'Brief Confirmed'
+
+    if project.status != 'Brief Pending Confirmation'
       raise Service::Error.new("project.not_pending_approval")
     end
 

--- a/spec/graphql/mutations/confirm_project_spec.rb
+++ b/spec/graphql/mutations/confirm_project_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'rails_helper'
 
 RSpec.describe Mutations::ConfirmProject do
@@ -20,7 +22,7 @@ RSpec.describe Mutations::ConfirmProject do
     GRAPHQL
   end
 
-  before :each do
+  before do
     allow_any_instance_of(Project).to receive(:sync_to_airtable)
   end
 
@@ -31,7 +33,7 @@ RSpec.describe Mutations::ConfirmProject do
   end
 
   context "when the status is not 'Biref Pending confirmation'" do
-    let(:project) { create(:project, status: 'Brief Confirmed') }
+    let(:project) { create(:project, status: 'Draft') }
 
     it 'returns an error' do
       response = AdvisableSchema.execute(query)

--- a/spec/services/projects/confirm_spec.rb
+++ b/spec/services/projects/confirm_spec.rb
@@ -1,4 +1,4 @@
-# frozen_String_literal: true
+# frozen_string_literal: true
 
 require "rails_helper"
 
@@ -26,6 +26,15 @@ RSpec.describe Projects::Confirm do
     it 'syncs with airtable' do
       expect(project).to receive(:sync_to_airtable)
       described_class.call(project: project)
+    end
+  end
+
+  context "when the project status is 'Brief Confirmed'" do
+    let(:project) { build(:project, status: "Brief Confirmed") }
+
+    it "returns the project" do
+      response = described_class.call(project: project)
+      expect(response).to eq(project)
     end
   end
 


### PR DESCRIPTION
Random bug that I found that causes the deposit step on old project setup flow to crash. With the new deposit flow in the newer project setup flows we moved the updated of the status to 'Brief Confirmed' into the stripe webhook.

The old flow marks the project has confirmed by calling the confirmProject mutation. Having the update also in the stripe webhook means that now by the time the told status calls the confirmProject mutation, the status might already be set to 'Brief Confirmed' and would raise an error. This fixes by allowing the status to be 'Brief Confirmed' inside of the confirm project mutation essentially making it idempotent.

### Reviewer Checklist

- [x] PR has a clear title and description
- [x] Manually tested the changes that the PR introduces
- [x] Changes introduced by the PR are covered by tests of acceptable quality
- [x] Checked the quality of [commit messages](http://chris.beams.io/posts/git-commit/)