### PR TITLE
Handle case when we don't find Guild Image

### DIFF
--- a/app/graphql/mutations/guild/delete_guild_post_image.rb
+++ b/app/graphql/mutations/guild/delete_guild_post_image.rb
@@ -5,7 +5,7 @@ class Mutations::Guild::DeleteGuildPostImage < Mutations::BaseMutation
 
   argument :guild_post_image_id, ID, required: true
 
-  field :image, Types::Guild::PostImageType, null: true
+  field :success, Boolean, null: true
 
   def authorized?(**args)
     requires_guild_user!
@@ -13,15 +13,14 @@ class Mutations::Guild::DeleteGuildPostImage < Mutations::BaseMutation
 
   def resolve(**args)
     image = Guild::PostImage.find_by(uid: args[:guild_post_image_id])
+    return {success: false} if image.blank?
 
-    if image.present?
-      if image.post.specialist != current_user
-        ApiError.not_authorized('You dont have access to this')
-      end
-
-      image.destroy
+    if image.post.specialist != current_user
+      ApiError.not_authorized('You dont have access to this')
     end
 
-    {image: image}
+    image.destroy
+
+    {success: true}
   end
 end

--- a/app/javascript/guild/components/ComposerModal/mutations.js
+++ b/app/javascript/guild/components/ComposerModal/mutations.js
@@ -75,12 +75,7 @@ export const useUpdateGuildPostImage = (props) =>
 export const DELETE_GUILD_POST_IMAGE = gql`
   mutation deleteGuildPostImage($input: DeleteGuildPostImageInput!) {
     deleteGuildPostImage(input: $input) {
-      image {
-        id
-        url
-        cover
-        position
-      }
+      success
     }
   }
 `;


### PR DESCRIPTION
Resolves: https://github.com/advisablecom/Advisable/issues/826

### Description

Sentry error was closed before, but reopened. It's a small change.

### Reviewer Checklist

- [ ] PR has a clear title and description
- [ ] Manually tested the changes that the PR introduces
- [ ] Changes introduced by the PR are covered by tests of acceptable quality
- [ ] Checked the quality of [commit messages](http://chris.beams.io/posts/git-commit/)
