### PR TITLE
Add distinct followers count for tag list

### DIFF
--- a/app/fields/acts_as_taggable_field.rb
+++ b/app/fields/acts_as_taggable_field.rb
@@ -8,7 +8,10 @@ class ActsAsTaggableField < Administrate::Field::Base
   end
 
   def delimited
-    data.map(&:name).join(", ")
+    if data.any?
+      followers_count = Follow.where(followable_id: data.map(&:id), followable_type: "ActsAsTaggableOn::Tag").distinct.count(:follower_id)
+      data.map(&:name).join(", ").concat(" - (#{followers_count})")
+    end
   end
 
   def attribute


### PR DESCRIPTION
Adds a count of distinct followers for all tags for a post displayed on the admin guild post show page.

We talked about possibly needing something like this in the admin to determine the impact of boosting a Post. Maybe this could work?

example below in parens

![Screen Shot 2021-01-27 at 2 47 31 PM](https://user-images.githubusercontent.com/34672/106096503-90082a00-60ea-11eb-80e9-c06a2872eb9e.png)




### Reviewer Checklist

- [ ] PR has a clear title and description
- [ ] Manually tested the changes that the PR introduces
- [ ] Changes introduced by the PR are covered by tests of acceptable quality
- [ ] Checked the quality of [commit messages](http://chris.beams.io/posts/git-commit/)
