### PR TITLE
Reduce slug size

### DIFF
--- a/.slugignore
+++ b/.slugignore
@@ -4,3 +4,7 @@ jest-coverage/
 coverage/
 app/javascript/*.test.js
 donut/*.test.js
+.vscode
+.circleci
+docs
+


### PR DESCRIPTION
### Description

Noticed this appearing in our build logs.

![image](https://user-images.githubusercontent.com/1512593/106742988-b01d7900-6615-11eb-862a-a4ef2bc7420b.png)

Will need to think of other ways we can reduce the slug but this should be a start by remove all test files.

### Reviewer Checklist

- [ ] PR has a clear title and description
- [ ] Manually tested the changes that the PR introduces
- [ ] Changes introduced by the PR are covered by tests of acceptable quality
- [ ] Checked the quality of [commit messages](http://chris.beams.io/posts/git-commit/)