### PR TITLE
Fix Message overflow on Guild

### DIFF
--- a/app/javascript/guild/views/Messages/components/Message.js
+++ b/app/javascript/guild/views/Messages/components/Message.js
@@ -94,6 +94,7 @@ export default function Message({ message, author, isAuthor }) {
             flexShrink="1"
             marginBottom={2}
             color="neutral800"
+            maxWidth={["250px", "280px", "360px", "520px", "640px"]}
             lineHeight="1.2rem"
             borderRadius="12px"
             bg={isAuthor ? "blue200" : "white"}
@@ -105,8 +106,8 @@ export default function Message({ message, author, isAuthor }) {
             <Text
               data-message
               css={`
-                white-space: pre-wrap;
                 white-space: pre-line;
+                overflow-wrap: break-word;
               `}
             >
               {message.body}


### PR DESCRIPTION
Resolves: [Ticket](https://airtable.com/tblzKtqH2SVFDMJBw/viweflCthZ8xQiFla/rec8UxGX2sfrQXZo0?blocks=hide)

### Description

I tried different approaches and creating a fixed maxWidth approach is so far the best. Initially, I wanted to make a restriction in percentages but it's not working in this case.

Also, I removed `white-space: pre-wrap` since I don't understand why we need two `white-space` definitions.

### Manual Testing Instructions

Steps:
1.
2.
3.

### Reviewer Checklist

- [ ] PR has a clear title and description
- [ ] Manually tested the changes that the PR introduces
- [ ] Changes introduced by the PR are covered by tests of acceptable quality
- [ ] Checked the quality of [commit messages](http://chris.beams.io/posts/git-commit/)

### Screenshots

Before                           | After
-------------------------------- | --------------------------------
![image](https://user-images.githubusercontent.com/849247/106892517-d8c87000-66f4-11eb-9248-444233281456.png) | ![image](https://user-images.githubusercontent.com/849247/106892428-bafb0b00-66f4-11eb-8540-254ba9dc9a01.png)


### Other

Provide additional notes, remarks, links, mention specific people to review,…
