### PR TITLE
Rescue MiniMagick errors

### DIFF
--- a/app/jobs/resize_image_job.rb
+++ b/app/jobs/resize_image_job.rb
@@ -5,5 +5,7 @@ class ResizeImageJob < ApplicationJob
 
   def perform(object, attachment_name, **options)
     object.public_send(attachment_name).variant(options).processed
+  rescue MiniMagick::Error => e
+    Raven.capture_exception(e, level: 'debug', extra: {object_class: object.class.name, object_id: object.id, name: attachment_name})
   end
 end


### PR DESCRIPTION
Resolves: #892

### Description

There's nothing we can really do. So we just rescue, so we don't try to do the same thing over and over again. And we report to Sentry if we ever have to debug this.

Ideally we'd prevent massive images like this from being uploaded in the first place.

### Reviewer Checklist

- [ ] PR has a clear title and description
- [ ] Manually tested the changes that the PR introduces
- [ ] Changes introduced by the PR are covered by tests of acceptable quality
- [ ] Checked the quality of [commit messages](http://chris.beams.io/posts/git-commit/)
