### PR TITLE
Fix guild admin pages

### DIFF
--- a/app/fields/acts_as_taggable_field.rb
+++ b/app/fields/acts_as_taggable_field.rb
@@ -11,11 +11,15 @@ class ActsAsTaggableField < Administrate::Field::Base
     data.map(&:name)&.join(", ")
   end
 
+  def name
+    context = super
+    followers_count = Follow.where(followable_id: data.map(&:id), followable_type: "ActsAsTaggableOn::Tag").distinct.count(:follower_id) if data.any?
+    "#{context} (#{followers_count || 0})"
+  end
+
   def attribute
     context = super.to_s.singularize
-    followers_count = Follow.where(followable_id: data.map(&:id), followable_type: "ActsAsTaggableOn::Tag").distinct.count(:follower_id) if data.any?
-
-    "#{context}_list (#{followers_count || 0})"
+    "#{context}_list"
   end
 
   def self.permitted_attribute(attr)


### PR DESCRIPTION
#890 Changed the attribute method to move the follows count to the field label, administrate also uses this to render the form and so raised an error. Looks like we can use the #name method instead to override the field label.

### Reviewer Checklist

- [ ] PR has a clear title and description
- [ ] Manually tested the changes that the PR introduces
- [ ] Changes introduced by the PR are covered by tests of acceptable quality
- [ ] Checked the quality of [commit messages](http://chris.beams.io/posts/git-commit/)