### PR TITLE
Removes key bindings unsupported in gfm

### DIFF
--- a/app/javascript/guild/components/RichTextEditor/index.js
+++ b/app/javascript/guild/components/RichTextEditor/index.js
@@ -38,8 +38,10 @@ export default function RichTextEditor({ value, onChange, onBlur }) {
         }
         return null;
       }
+      const binding = getDefaultKeyBinding(e);
 
-      return getDefaultKeyBinding(e);
+      // ignore bindings that arent supported by react markdown
+      return /italic|underline/.test(binding) ? null : binding;
     },
     [editorState, setEditorState],
   );


### PR DESCRIPTION
Resolves: [Formatting "Bold" For Guild post became ++ when published ](https://airtable.com/tblzKtqH2SVFDMJBw/viwNruI2lhO1UUmBo/recrcFzflcrOAWTWf)

* This removes draftjs key bindings ( underline and italic ) that are not supported in github flavored markdown ( remark-gfm powers the editor )

### Reviewer Checklist

- [ ] PR has a clear title and description
- [ ] Manually tested the changes that the PR introduces
- [ ] Changes introduced by the PR are covered by tests of acceptable quality
- [ ] Checked the quality of [commit messages](http://chris.beams.io/posts/git-commit/)
