### PR TITLE
Fix reviews not returning name or avatar

### DIFF
--- a/app/graphql/types/review.rb
+++ b/app/graphql/types/review.rb
@@ -19,19 +19,20 @@ module Types
     end
 
     def avatar
-      return unless project.is_a?(PreviousProject)
+      return unless project.is_a?(::PreviousProject)
 
       project.resized_contact_image_url
     end
 
     def name
-      return project.user.account.name if project.is_a?(Project)
+      return project.user.account.name if project.is_a?(::Project)
+      return nil if project&.confidential?
 
-      project.contact_name if project&.confidential?
+      project.contact_name
     end
 
     def role
-      if project.is_a?(Project)
+      if project.is_a?(::Project)
         project.user.title
       else
         project.try(:contact_job_title)
@@ -39,7 +40,7 @@ module Types
     end
 
     def company_name
-      if project.is_a?(Project)
+      if project.is_a?(::Project)
         project.user.company_name
       else
         previous_project_company_name(project)


### PR DESCRIPTION
[Paipas issue](https://airtable.com/tblzKtqH2SVFDMJBw/viweflCthZ8xQiFla/reci8jD0Kx9Gp6Rzg?blocks=hide)

1. We had accidentally used the wrong conditional and only returned review name if the project was confidential, this was meant to be the opposite.
2. Due to class name spacing the avatar was never returned.

### Reviewer Checklist

- [ ] PR has a clear title and description
- [ ] Manually tested the changes that the PR introduces
- [ ] Changes introduced by the PR are covered by tests of acceptable quality
- [ ] Checked the quality of [commit messages](http://chris.beams.io/posts/git-commit/)