### PR TITLE
Fix bullet point component issues

### DIFF
--- a/app/javascript/src/components/BulletPointInput/index.js
+++ b/app/javascript/src/components/BulletPointInput/index.js
@@ -22,7 +22,8 @@ export default function BulletPointInput({
 
     // backspace
     if (e.keyCode === 8 && inputValue.length === 0) {
-      if (!nextInput) {
+      if (previousInput) {
+        e.preventDefault();
         previousInput.querySelector("textarea").focus();
       }
 

--- a/app/javascript/src/components/BulletPointInput/styles.js
+++ b/app/javascript/src/components/BulletPointInput/styles.js
@@ -40,8 +40,7 @@ export const StyledBulletPointInputItem = styled.div`
     margin: 0;
     outline: none;
 
-    &:focus {
-      background: transparent;
+    &[data-focused="true"] {
       border-color: transparent;
     }
   }

--- a/donut/src/components/Input/index.js
+++ b/donut/src/components/Input/index.js
@@ -44,7 +44,7 @@ const Input = React.forwardRef(function Input(
   return (
     <StyledInput
       ref={containerRef}
-      $focused={focused}
+      data-focused={focused}
       $error={error}
       $disabled={props.disabled}
       size={size}

--- a/donut/src/components/Input/styles.js
+++ b/donut/src/components/Input/styles.js
@@ -79,11 +79,6 @@ const StyledInput_Error = css`
   }
 `;
 
-const StyledInput_Focused = css`
-  background-color: #eff0f3;
-  border-color: ${theme.colors.blue900};
-`;
-
 const StyledInput_Disabled = css`
   cursor: not-allowed;
   border-color: ${lighten(0.024, "#eff0f3")};
@@ -164,8 +159,12 @@ export const StyledInput = styled.div`
   border-radius: ${BORDER_RADIUS}px;
   background: #eff0f3;
   ${(props) => props.$error && StyledInput_Error};
-  ${(props) => props.$focused && StyledInput_Focused};
   ${(props) => props.$disabled && StyledInput_Disabled};
+
+  &[data-focused="true"] {
+    background-color: #eff0f3;
+    border-color: ${theme.colors.blue900};
+  }
 
   ${size}
   ${margin};

--- a/donut/src/components/Textarea/index.js
+++ b/donut/src/components/Textarea/index.js
@@ -43,11 +43,17 @@ const Textarea = React.forwardRef(function Textarea(
     textarea.current.rows = rows;
   }
 
-  React.useLayoutEffect(calculateRows, [props.value]);
+  React.useLayoutEffect(calculateRows, [
+    props.value,
+    props.lineHeight,
+    props.maxRows,
+    props.minRows,
+    props.rowPadding,
+  ]);
 
   return (
     <StyledTextarea
-      $focused={focused}
+      data-focused={focused}
       $error={error}
       $disabled={props.disabled}
       size={size}


### PR DESCRIPTION
Resolves: [Sentry Error](https://sentry.io/organizations/advisable/issues/2221524871/?project=2019647&query=is%3Aunresolved&statsPeriod=14d)

### Description

This should have been checking for the presence of a previous input not a next one, which meant that when a user pressed the backspace when the input was empty it would log an error.

There was also some styling issues with the focused state so I opted to use data attributes rather than styled components props for input focused state.

### Reviewer Checklist

- [ ] PR has a clear title and description
- [ ] Manually tested the changes that the PR introduces
- [ ] Changes introduced by the PR are covered by tests of acceptable quality
- [ ] Checked the quality of [commit messages](http://chris.beams.io/posts/git-commit/)

<img width="819" alt="Screenshot 2021-02-17 at 15 24 34" src="https://user-images.githubusercontent.com/1512593/108229402-b2b0c000-7137-11eb-8211-01f566134ac5.png">
<img width="819" alt="Screenshot 2021-02-17 at 15 45 54" src="https://user-images.githubusercontent.com/1512593/108229414-b6444700-7137-11eb-95c9-8666ed3c23b9.png">
