### PR TITLE
Redirect if session is stale w/ guildPosts query

### DIFF
--- a/app/graphql/types/query_type.rb
+++ b/app/graphql/types/query_type.rb
@@ -201,7 +201,7 @@ module Types
 
     field :guild_posts,
           Types::Guild::PostInterface.connection_type,
-          null: false, max_page_size: 5 do
+          null: true, max_page_size: 5 do
       description 'Returns a list of guild posts for the feed'
 
       argument :type, String, required: false do


### PR DESCRIPTION
Resolves: [Handle unauthenticated error](https://airtable.com/tblzKtqH2SVFDMJBw/viwNruI2lhO1UUmBo/recWCo4tOCLJr9Lpr)

Possibly fixes a strange error that we think has to do with a stale session when querying guildPosts.

Note: Couldn't think of a 'good' way to test a stale viewer here w/ a system spec;  You can replicate (maybe?) the sentry errors in the associated ticket above by returning `ApiError.not_authenticated` in the query endpoint but you need to be logged in .. keep in mind this will loop since you actually have a valid session and is more a way to test the error handler.


### Reviewer Checklist

- [ ] PR has a clear title and description
- [ ] Manually tested the changes that the PR introduces
- [ ] Changes introduced by the PR are covered by tests of acceptable quality
- [ ] Checked the quality of [commit messages](http://chris.beams.io/posts/git-commit/)
