### PR TITLE
Redirect to login on post page

### DIFF
--- a/app/javascript/guild/utils.js
+++ b/app/javascript/guild/utils.js
@@ -56,3 +56,11 @@ export const cursorLoadMore = ({ fetchMore, collectionKey, data }) => {
     },
   });
 };
+
+export const hasGqlError = (code, errors) =>
+  errors?.graphQLErrors?.[0]?.extensions?.code === code;
+
+export const loginWithRedirectPath = (path) => {
+  const redirect = encodeURIComponent(`/guild${path}`);
+  window.location = `/login?redirect=${redirect}`;
+};

--- a/spec/system/guild_view_post_spec.rb
+++ b/spec/system/guild_view_post_spec.rb
@@ -1,0 +1,41 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe "Guild view post", type: :system do
+  let(:account) { create(:account, completed_tutorials: ["GUILD"]) }
+  let(:specialist) { create(:specialist, guild: true, account: account) }
+  let!(:guild_post) { create(:guild_post, shareable: false, title: "This is a test post") }
+  let(:post_path) { "/guild/posts/#{guild_post.id}" }
+
+  context "when not logged in" do
+    it "is redirected to login page with the post link" do
+      visit(post_path)
+      expect(page).to have_content("Please sign in to your account")
+      expect(page).to have_current_path("/login?redirect=#{post_path}")
+    end
+
+    it "is not redirected to login page when post is public" do
+      guild_post.update! shareable: true
+      visit(post_path)
+      expect(page).not_to have_content("Please sign in to your account")
+      expect(page).to have_content(guild_post.title)
+    end
+  end
+
+  context "when logged in" do
+    before do
+      authenticate_as(specialist)
+    end
+
+    it "has a not found notice if there is no post" do
+      visit("#{post_path}123")
+      expect(page).to have_content("Post not found")
+    end
+
+    it "displays the post" do
+      visit(post_path)
+      expect(page).to have_content(guild_post.title)
+    end
+  end
+end


### PR DESCRIPTION
Resolves: [Have a Please log in to see this post](https://airtable.com/tblzKtqH2SVFDMJBw/viwow37Q77ajPTcO4/recXntOOWAuB0xjw2)

It was reported that some posts that were boosted were displaying the not found notice which was the behavior if the viewer wasn't authenticated.  I'm guessing this was a result of someone copying a non magic link in the address bar and sharing with another guild member since the actual link in the boosted mailer is a magic link and will log them in.

Added something to redirect to the login page if the viewer isn't logged in

### Reviewer Checklist

- [ ] PR has a clear title and description
- [ ] Manually tested the changes that the PR introduces
- [ ] Changes introduced by the PR are covered by tests of acceptable quality
- [ ] Checked the quality of [commit messages](http://chris.beams.io/posts/git-commit/)
