### PR TITLE
Fix acts_as_taggable_field in administrate

### DIFF
--- a/app/fields/acts_as_taggable_field.rb
+++ b/app/fields/acts_as_taggable_field.rb
@@ -22,7 +22,7 @@ class ActsAsTaggableField < Administrate::Field::Base
     "#{context}_list"
   end
 
-  def self.permitted_attribute(attr)
+  def self.permitted_attribute(attr, _options = nil)
     context = super.to_s.singularize
     {"#{context}_list" => []}
   end


### PR DESCRIPTION
[sentry error](https://sentry.io/organizations/advisable/issues/2246855185/?project=2021209&query=is%3Aunresolved&statsPeriod=14d)

Administrate changed their permitted_attributes method to take an options argument.

### Reviewer Checklist

- [ ] PR has a clear title and description
- [ ] Manually tested the changes that the PR introduces
- [ ] Changes introduced by the PR are covered by tests of acceptable quality
- [ ] Checked the quality of [commit messages](http://chris.beams.io/posts/git-commit/)
