### PR TITLE
Fix tooltips taking up page space

### DIFF
--- a/donut/src/components/Tooltip/index.js
+++ b/donut/src/components/Tooltip/index.js
@@ -61,7 +61,7 @@ const StyledTooltip = styled(ExtractedReakitTooltip)`
   cursor: default;
   z-index: 999999;
   visibility: hidden;
-  display: block !important;
+  display: block;
 
   ${(props) => props.visible && openStyling};
   ${(props) => props.interactable && interactableStyling}


### PR DESCRIPTION
Resolves: [Ticket](https://airtable.com/tblzKtqH2SVFDMJBw/viweflCthZ8xQiFla/rec8wF71ftP0og8dv?blocks=hide)

### Description

When a tooltip was hidden, the display: block was still applied because
of !important. This meant that the element was still taking up space in
the layout of the page causing weird page layouts on guild.

### Reviewer Checklist

- [ ] PR has a clear title and description
- [ ] Manually tested the changes that the PR introduces
- [ ] Changes introduced by the PR are covered by tests of acceptable quality
- [ ] Checked the quality of [commit messages](http://chris.beams.io/posts/git-commit/)