### PR TITLE
Do not use AR classes in migrations

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -76,6 +76,10 @@ Style/StringLiterals:
   Enabled: false
   EnforcedStyle: double_quotes
 
+Rails/SkipsModelValidations:
+  Exclude:
+    - "db/migrate/*"
+
 Rails/DynamicFindBy:
   Enabled: false
 

--- a/db/migrate/20210208101504_add_published_to_taggable.rb
+++ b/db/migrate/20210208101504_add_published_to_taggable.rb
@@ -1,10 +1,14 @@
 # frozen_string_literal: true
 
 class AddPublishedToTaggable < ActiveRecord::Migration[6.1]
+  class MigrationTopic < ApplicationRecord
+    self.table_name = :tags
+  end
+
   def up
     add_column ActsAsTaggableOn.tags_table, :published, :boolean, default: false
 
-    Guild::Topic.find_each do |topic|
+    MigrationTopic.find_each do |topic|
       topic.published = true
       topic.save(touch: false, validate: false)
     end

--- a/db/migrate/20210210124607_copy_bank_transfers_enabled_from_user_to_company.rb
+++ b/db/migrate/20210210124607_copy_bank_transfers_enabled_from_user_to_company.rb
@@ -1,8 +1,16 @@
 # frozen_string_literal: true
 
 class CopyBankTransfersEnabledFromUserToCompany < ActiveRecord::Migration[6.1]
+  class MigrationUser < ApplicationRecord
+    self.table_name = :users
+  end
+
+  class MigrationCompany < ApplicationRecord
+    self.table_name = :companies
+  end
+
   def up
-    company_ids = User.where(bank_transfers_enabled: true).pluck(:company_id)
-    Company.where(id: company_ids).update_all(bank_transfers_enabled: true) # rubocop:disable Rails/SkipsModelValidations
+    company_ids = MigrationUser.where(bank_transfers_enabled: true).pluck(:company_id)
+    MigrationCompany.where(id: company_ids).update_all(bank_transfers_enabled: true)
   end
 end

--- a/db/migrate/20210217200148_add_notifications_from_reactions.rb
+++ b/db/migrate/20210217200148_add_notifications_from_reactions.rb
@@ -1,7 +1,0 @@
-# frozen_string_literal: true
-
-class AddNotificationsFromReactions < ActiveRecord::Migration[6.1]
-  def up
-    Guild::Reaction.order(:created_at).find_each { |r| r.create_notification!(read_at: Time.current) }
-  end
-end

--- a/db/migrate/20210302103819_copy_vat_to_specialist.rb
+++ b/db/migrate/20210302103819_copy_vat_to_specialist.rb
@@ -1,10 +1,18 @@
 # frozen_string_literal: true
 
 class CopyVatToSpecialist < ActiveRecord::Migration[6.1]
+  class MigrationAccount < ApplicationRecord
+    self.table_name = :accounts
+  end
+
+  class MigrationSpecialist < ApplicationRecord
+    self.table_name = :specialists
+  end
+
   def up
-    vat_numbers = Account.where.not(vat_number: ['', nil]).pluck(:id, :vat_number).to_h
-    Specialist.where(account_id: vat_numbers.keys).find_each do |specialist|
-      specialist.update_columns(vat_number: vat_numbers[specialist.account_id]) # rubocop:disable Rails/SkipsModelValidations
+    vat_numbers = MigrationAccount.where.not(vat_number: ['', nil]).pluck(:id, :vat_number).to_h
+    MigrationSpecialist.where(account_id: vat_numbers.keys).find_each do |specialist|
+      specialist.update_columns(vat_number: vat_numbers[specialist.account_id])
     end
   end
 end


### PR DESCRIPTION
### Description

If you ran migrations from scratch recently you might have gotten:

```
rake aborted!
ActiveRecord::StatementInvalid: PG::UndefinedColumn: ERROR:  column accounts.vat_number does not exist
LINE 1: ...."permissions", "accounts"."completed_tutorials", "accounts"...
```

originating from [app/services/test_data.rb:194](https://github.com/advisablecom/Advisable/blob/765d4b552aa94191b62d8d0e5ca745b2d96881ee/app/services/test_data.rb#L194)

But, you say, there is no `vat_number` there 🤔 

The reason is in [db/migrate/20210302103819_copy_vat_to_specialist.rb](https://github.com/advisablecom/Advisable/blob/765d4b552aa94191b62d8d0e5ca745b2d96881ee/db/migrate/20210302103819_copy_vat_to_specialist.rb)

But, you say, how? Wat? Huh?

Well, you see, because I call `Account` Rails goes and loads up the class and filters by `vat_number` that I give it there. The query is empty so migrations pass with flying colors. But now Rails thinks that Account has `vat_number` and next time it inserts into the table it helpfully tells Postgres about it. And pg is like - wait what??? I've never heard of no `vat_number` column on `accounts`! Error, error, error 🚨

I've faced this kind of errors in the past and you can read more about them [here](https://blog.testdouble.com/posts/2014-11-04-healthy-migration-habits/). In order to prevent them I've added [good migrations](https://github.com/testdouble/good-migrations) a while back. However, turns out, it's [broken under Zeitwerk](https://github.com/testdouble/good-migrations/issues/9) 😒

I went through all the existing migrations and updated them. One of them is simply too complex and not needed anymore (it ran already in production) so I just removed it.

### Reviewer Checklist

- [ ] PR has a clear title and description
- [ ] Manually tested the changes that the PR introduces
- [ ] Changes introduced by the PR are covered by tests of acceptable quality
- [ ] Checked the quality of [commit messages](http://chris.beams.io/posts/git-commit/)
