### PR TITLE
Remove project from ApplicationReference

### DIFF
--- a/app/models/application_reference.rb
+++ b/app/models/application_reference.rb
@@ -1,8 +1,6 @@
 # frozen_string_literal: true
 
 class ApplicationReference < ApplicationRecord
-  self.ignored_columns += %i[project_id project_type]
-
   include Uid
   uid_prefix 'ref'
 
@@ -25,7 +23,6 @@ end
 #
 #  index_application_references_on_application_id           (application_id)
 #  index_application_references_on_off_platform_project_id  (off_platform_project_id)
-#  index_application_references_on_project                  (project_type,project_id)
 #  index_application_references_on_uid                      (uid)
 #
 # Foreign Keys

--- a/db/migrate/20210318120807_remove_project_from_application_reference.rb
+++ b/db/migrate/20210318120807_remove_project_from_application_reference.rb
@@ -1,0 +1,9 @@
+# frozen_string_literal: true
+
+class RemoveProjectFromApplicationReference < ActiveRecord::Migration[6.1]
+  def change
+    safety_assured do
+      remove_reference :application_references, :project, polymorphic: true
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2021_03_17_095209) do
+ActiveRecord::Schema.define(version: 2021_03_18_120807) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "citext"
@@ -95,14 +95,11 @@ ActiveRecord::Schema.define(version: 2021_03_17_095209) do
   create_table "application_references", force: :cascade do |t|
     t.string "uid"
     t.bigint "application_id"
-    t.string "project_type"
-    t.bigint "project_id"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
     t.bigint "off_platform_project_id"
     t.index ["application_id"], name: "index_application_references_on_application_id"
     t.index ["off_platform_project_id"], name: "index_application_references_on_off_platform_project_id"
-    t.index ["project_type", "project_id"], name: "index_application_references_on_project"
     t.index ["uid"], name: "index_application_references_on_uid"
   end
 


### PR DESCRIPTION
### Description

Follow up from #974

Before deploying we should run
`ApplicationReference.where(project_type: "Project").destroy_all`
via console.

### Reviewer Checklist

- [x] PR has a clear title and description
- [x] Manually tested the changes that the PR introduces
- [ ] Changes introduced by the PR are covered by tests of acceptable quality
- [ ] Checked the quality of [commit messages](http://chris.beams.io/posts/git-commit/)