### PR TITLE
Include released_at and page_load timestamps in sentry context

### DIFF
--- a/app/javascript/guild/index.js
+++ b/app/javascript/guild/index.js
@@ -9,6 +9,11 @@ if (process.env.SENTRY_FRONTEND_DSN) {
     dsn: `${process.env.SENTRY_FRONTEND_DSN}`,
     environment: process.env.SENTRY_ENVIRONMENT,
   });
+
+  Sentry.setContext("session", {
+    page_load: new Date().toISOString(),
+    released_at: process.env.RELEASED_AT,
+  });
 }
 
 document.addEventListener("DOMContentLoaded", () => {

--- a/app/javascript/src/index.js
+++ b/app/javascript/src/index.js
@@ -9,6 +9,11 @@ if (process.env.SENTRY_FRONTEND_DSN) {
     dsn: `${process.env.SENTRY_FRONTEND_DSN}`,
     environment: process.env.SENTRY_ENVIRONMENT,
   });
+
+  Sentry.setContext("session", {
+    page_load: new Date().toISOString(),
+    released_at: process.env.RELEASED_AT,
+  });
 }
 
 document.addEventListener("DOMContentLoaded", () => {


### PR DESCRIPTION
Gives us a little more information for debugging sentry errors. This introduces a "page_load" timestamp to the Sentry context which tells us when the user last did a full page refresh.

### Reviewer Checklist

- [ ] PR has a clear title and description
- [ ] Manually tested the changes that the PR introduces
- [ ] Changes introduced by the PR are covered by tests of acceptable quality
- [ ] Checked the quality of [commit messages](http://chris.beams.io/posts/git-commit/)

![Screenshot 2021-03-18 at 16 04 02](https://user-images.githubusercontent.com/1512593/111658919-b43bd980-8804-11eb-9cd1-93a47b63847f.png)
