### PR TITLE
Remove color from post type tag

### DIFF
--- a/app/javascript/guild/components/Post/index.js
+++ b/app/javascript/guild/components/Post/index.js
@@ -32,14 +32,14 @@ const Post = ({
     <Sentry.ErrorBoundary>
       <Card
         position="relative"
-        padding={[4, 8]}
+        padding={[4, 6]}
         borderRadius="12px"
         width="100%"
         border="2px solid"
         borderColor={post.pinned ? "neutral400" : "white"}
         data-testid="post"
       >
-        <Box position="absolute" right="4" top="4">
+        <Box position="absolute" right="2" top="2">
           <PostTypeTag post={post} />
         </Box>
 

--- a/app/javascript/guild/components/PostTypeTag.js
+++ b/app/javascript/guild/components/PostTypeTag.js
@@ -10,22 +10,19 @@ const TYPES = {
   GuildPostAdviceRequired: {
     children: "Advice required",
     icon: Support,
-    variant: "orange",
   },
   GuildPostCaseStudy: {
     children: "Case study",
     icon: ChartSquareBar,
-    variant: "cyan",
   },
   GuildPostOpportunity: {
     children: "Opportunity",
     icon: UserGroup,
-    variant: "blue",
   },
 };
 
 export default function PostTypeTag({ post, size }) {
   const postType = TYPES[post.__typename];
   if (!postType) return null;
-  return <Tag size={size || ["s", "m"]} {...TYPES[post.__typename]} />;
+  return <Tag size={size || "s"} {...TYPES[post.__typename]} />;
 }


### PR DESCRIPTION
Tidy up the post type tags by removing color, making them smaller and reducing margins. It isn't crucial information and they are taking up too much attention at the moment.

<img width="891" alt="Screenshot 2021-03-22 at 18 40 11" src="https://user-images.githubusercontent.com/1512593/112114309-d3918880-8baf-11eb-9c3c-77f5ebe28640.png">


### Reviewer Checklist

- [ ] PR has a clear title and description
- [ ] Manually tested the changes that the PR introduces
- [ ] Changes introduced by the PR are covered by tests of acceptable quality
- [ ] Checked the quality of [commit messages](http://chris.beams.io/posts/git-commit/)