### PR TITLE
Fix italic fonts in safari

### DIFF
--- a/donut/src/components/Provider/BaseStyles.js
+++ b/donut/src/components/Provider/BaseStyles.js
@@ -8,6 +8,10 @@ const BACKGROUND = {
 };
 
 const BaseStyles = createGlobalStyle`
+  :root {
+    font-variation-settings: "ital" 0, "slnt" 0;
+  }
+
   * {
     box-sizing: border-box;
   }


### PR DESCRIPTION
Fonts were rendering as italics in safari due to a [bug in safari](https://twitter.com/rsms/status/1102265361360052224?ref_src=twsrc%5Etfw%7Ctwcamp%5Etweetembed%7Ctwterm%5E1102265361360052224%7Ctwgr%5E%7Ctwcon%5Es1_c10&ref_url=https%3A%2F%2Fmatthewstrom.com%2Fwriting%2Fvariable-fonts%2F). 

before
![Screenshot 2021-03-23 at 11 08 55](https://user-images.githubusercontent.com/1512593/112137616-60484080-8bc8-11eb-8bd1-f0c397585862.png)

After
![Screenshot 2021-03-23 at 11 09 01](https://user-images.githubusercontent.com/1512593/112137617-62120400-8bc8-11eb-8083-9493276e86dd.png)
