### PR TITLE
Copy post tags to labels

### DIFF
--- a/app/graphql/mutations/guild/update_guild_post.rb
+++ b/app/graphql/mutations/guild/update_guild_post.rb
@@ -29,6 +29,11 @@ module Mutations
 
         if (guild_topic_names = args[:guild_topic_names].presence)
           guild_post.guild_topic_list = guild_topic_names
+
+          # TODO: AATO - save list, so we persist tags and taggings
+          guild_post.save
+          # TODO: AATO - reload to get the new tags, find topics by those ids and get their label mirrors
+          guild_post.labels = ::Guild::Topic.where(id: guild_post.reload.guild_topics.pluck(:id)).map(&:label_mirror)
         end
 
         # - A removed post cannot be published

--- a/spec/graphql/mutations/guild/update_guild_post_spec.rb
+++ b/spec/graphql/mutations/guild/update_guild_post_spec.rb
@@ -145,7 +145,8 @@ RSpec.describe Mutations::Guild::UpdateGuildPost do
         expect do
           update_guild_post.call(query)
           guild_post.reload
-        end.to change { guild_post.guild_topics.count }.from(0).to(3)
+        end.to change { guild_post.guild_topics.count }.from(0).to(3).
+          and change { guild_post.labels.count }.from(0).to(3)
       end
 
       it "creates new topic names" do
@@ -161,6 +162,12 @@ RSpec.describe Mutations::Guild::UpdateGuildPost do
         expect(new_topic.name).to eq("the razor crest")
         expect(new_topic.slug).to eq("the-razor-crest")
         expect(new_topic.published).to eq(false)
+
+        new_label = guild_post.reload.labels.first
+
+        expect(new_label.name).to eq("the razor crest")
+        expect(new_label.slug).to eq("the-razor-crest")
+        expect(new_label.published_at).to be_nil
       end
 
       it "does not change the status to draft if removed" do


### PR DESCRIPTION
### Description

Forgot about this when doing acts_as_taggable removal step 1.

Split into 2 commits because there was a ton of RuboCop noise.

### Reviewer Checklist

- [ ] PR has a clear title and description
- [ ] Manually tested the changes that the PR introduces
- [ ] Changes introduced by the PR are covered by tests of acceptable quality
- [ ] Checked the quality of [commit messages](http://chris.beams.io/posts/git-commit/)
