### PR TITLE
Remove validatOnMount on application flow terms step

### DIFF
--- a/app/javascript/src/views/ApplicationFlow/Terms/index.js
+++ b/app/javascript/src/views/ApplicationFlow/Terms/index.js
@@ -60,7 +60,6 @@ function Terms({ match, history, application, location }) {
         onSubmit={handleSubmit}
         initialValues={initialValues}
         validationSchema={validationSchema}
-        validateOnMount
       >
         {(formik) => (
           <Form>


### PR DESCRIPTION
Turns out the `validateOnMount` prop in formik also runs validation if the `initialValues` change. Except there seems to be a bug at the moment where it still uses the old initialValues rather than the new ones. This was causing the rate field to flash an error when submitting the form and then we continue on because the request was still actually successful. Really weird.

I've decided for now to just remove the validateOnMount prop because we aren't really using it in on the button.

https://formik.org/docs/api/withFormik#validateonmount-boolean

### Reviewer Checklist

- [ ] PR has a clear title and description
- [ ] Manually tested the changes that the PR introduces
- [ ] Changes introduced by the PR are covered by tests of acceptable quality
- [ ] Checked the quality of [commit messages](http://chris.beams.io/posts/git-commit/)
