### PR TITLE
Fix flaky event spec

### DIFF
--- a/spec/system/event_spec.rb
+++ b/spec/system/event_spec.rb
@@ -48,8 +48,8 @@ RSpec.describe 'Event view', type: :system do
       event.update!(host: specialist)
 
       visit "/guild/events/#{event.uid}"
-      expect(page).not_to have_content('Register for event')
-      expect(page).not_to have_content('Unregister')
+      expect(page).to have_content(event.title)
+      expect(page).to have_button('Register for event', disabled: true)
     end
 
     it "shows the remaining number of attendees beyond 20" do


### PR DESCRIPTION
Was failing for me locally. Capybara assertion was passing before page had actually loaded.

### Reviewer Checklist

- [ ] PR has a clear title and description
- [ ] Manually tested the changes that the PR introduces
- [ ] Changes introduced by the PR are covered by tests of acceptable quality
- [ ] Checked the quality of [commit messages](http://chris.beams.io/posts/git-commit/)
