### PR TITLE
Run webpack speed measure in each environment

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -8,7 +8,6 @@ module.exports = {
     "eslint:recommended",
     "eslint-config-prettier",
     "plugin:react/recommended",
-    "plugin:cypress/recommended",
   ],
   settings: {
     react: {

--- a/config/webpack/development.js
+++ b/config/webpack/development.js
@@ -3,6 +3,8 @@ process.env.NODE_ENV = process.env.NODE_ENV || "development";
 const ReactRefreshWebpackPlugin = require("@pmmmwh/react-refresh-webpack-plugin");
 const environment = require("./environment");
 const WebpackBar = require("webpackbar");
+const SpeedMeasurePlugin = require("speed-measure-webpack-plugin");
+const smp = new SpeedMeasurePlugin();
 
 // webpacker includes CaseSensitivePaths plugin and its slow.
 environment.plugins.delete("CaseSensitivePaths");
@@ -40,4 +42,5 @@ if (process.env.REACT_REFRESH === "true" && process.env.RAILS_ENV !== "test") {
   });
 }
 
-module.exports = environment.toWebpackConfig();
+console.log("Compiling webpack with development config");
+module.exports = smp.wrap(environment.toWebpackConfig());

--- a/config/webpack/production.js
+++ b/config/webpack/production.js
@@ -1,4 +1,6 @@
 const SentryWebpackPlugin = require("@sentry/webpack-plugin");
+const SpeedMeasurePlugin = require("speed-measure-webpack-plugin");
+const smp = new SpeedMeasurePlugin();
 
 process.env.NODE_ENV = process.env.NODE_ENV || "production";
 
@@ -20,4 +22,5 @@ if (
   );
 }
 
-module.exports = environment.toWebpackConfig();
+console.log("Compiling webpack with production config");
+module.exports = smp.wrap(environment.toWebpackConfig());

--- a/config/webpack/test.js
+++ b/config/webpack/test.js
@@ -1,6 +1,8 @@
 process.env.NODE_ENV = process.env.NODE_ENV || "development";
 
 const environment = require("./environment");
+const SpeedMeasurePlugin = require("speed-measure-webpack-plugin");
+const smp = new SpeedMeasurePlugin();
 
-const config = environment.toWebpackConfig();
-module.exports = config;
+console.log("Compiling webpack with test config");
+module.exports = smp.wrap(environment.toWebpackConfig());

--- a/package.json
+++ b/package.json
@@ -82,6 +82,7 @@
     "twilio-video": "^2.13.1",
     "url-regex": "^5.0.0",
     "use-sound": "^1.0.2",
+    "speed-measure-webpack-plugin": "^1.5.0",
     "webpack-bundle-analyzer": "^4.4.0",
     "yup": "^0.32.9",
     "zustand": "^3.3.3"

--- a/yarn.lock
+++ b/yarn.lock
@@ -15488,6 +15488,13 @@ spdy@^4.0.2:
     select-hose "^2.0.0"
     spdy-transport "^3.0.0"
 
+speed-measure-webpack-plugin@^1.5.0:
+  version "1.5.0"
+  resolved "https://registry.yarnpkg.com/speed-measure-webpack-plugin/-/speed-measure-webpack-plugin-1.5.0.tgz#caf2c5bee24ab66c1c7c30e8daa7910497f7681a"
+  integrity sha512-Re0wX5CtM6gW7bZA64ONOfEPEhwbiSF/vz6e2GvadjuaPrQcHTQdRGsD8+BE7iUOysXH8tIenkPCQBEcspXsNg==
+  dependencies:
+    chalk "^4.1.0"
+
 split-on-first@^1.0.0:
   version "1.1.0"
   resolved "https://registry.yarnpkg.com/split-on-first/-/split-on-first-1.1.0.tgz#f610afeee3b12bce1d0c30425e76398b78249a5f"


### PR DESCRIPTION
Runs the webpack speed measure plugin in each environment to help us monitor and improve build times.

![Screenshot 2021-03-30 at 11 02 13](https://user-images.githubusercontent.com/1512593/112973053-cdb81c00-9148-11eb-851b-42d9e4d57525.png)

Also includes a fix for the warning we are getting from eslint right now after removing cypress.

```
ESLint couldn't find the plugin "eslint-plugin-cypress".
```

### Reviewer Checklist

- [ ] PR has a clear title and description
- [ ] Manually tested the changes that the PR introduces
- [ ] Changes introduced by the PR are covered by tests of acceptable quality
- [ ] Checked the quality of [commit messages](http://chris.beams.io/posts/git-commit/)