### PR TITLE
Fix overlap of clipboard notification

### DIFF
--- a/app/javascript/src/components/CopyURL/styles.js
+++ b/app/javascript/src/components/CopyURL/styles.js
@@ -1,5 +1,6 @@
 import { rgba } from "polished";
 import styled, { keyframes } from "styled-components";
+import { theme } from "@advisable/donut";
 
 const copiedAnimation = keyframes`
   0% {
@@ -21,7 +22,7 @@ export const CopyURL = styled.div`
   margin: 0 auto;
   max-width: 100%;
   position: relative;
-  background: ${props => props.bg || "#f5f7ff"};
+  background: ${(props) => props.bg || "#f5f7ff"};
   border-radius: 30px;
 
   &::after {
@@ -36,8 +37,8 @@ export const CopyURL = styled.div`
     border-bottom-right-radius: 50px;
     background: linear-gradient(
       270deg,
-      ${props => props.bg || "#f5f7ff"} 70%,
-      ${props => rgba(props.bg || "#f5f7ff", 0)} 100%
+      ${(props) => props.bg || "#f5f7ff"} 70%,
+      ${(props) => rgba(props.bg || "#f5f7ff", 0)} 100%
     );
   }
 
@@ -79,10 +80,14 @@ export const CopyURL = styled.div`
 
   span {
     right: 0;
-    top: -20px;
+    top: -24px;
     color: #173fcd;
     font-size: 12px;
     position: absolute;
+    background: white;
+    padding: ${theme.space[1]};
+    border-radius: 4px;
+
     animation: ${copiedAnimation} 1.5s cubic-bezier(0.3, 0, 0, 1) forwards;
   }
 `;


### PR DESCRIPTION
### Description

Just add a white background to the clipboard notification.

### Before
![image](https://user-images.githubusercontent.com/849247/113193247-6ee9c400-9268-11eb-9ae2-8843b546dbdf.png)

### After
![image](https://user-images.githubusercontent.com/849247/113193441-a35d8000-9268-11eb-8dd0-9369cf07bdaf.png)

### Reviewer Checklist

- [ ] PR has a clear title and description
- [ ] Manually tested the changes that the PR introduces
- [ ] Changes introduced by the PR are covered by tests of acceptable quality
- [ ] Checked the quality of [commit messages](http://chris.beams.io/posts/git-commit/)

