### PR TITLE
Fix zero-padded day on event page

### DIFF
--- a/spec/system/event_spec.rb
+++ b/spec/system/event_spec.rb
@@ -22,7 +22,7 @@ RSpec.describe 'Event view', type: :system do
           expect(page).to have_content(event.title)
           expect(page).to have_content(event.description)
 
-          starts_at = event.starts_at.strftime("%d %b at %-l:%M%P")
+          starts_at = event.starts_at.strftime("%-d %b at %-l:%M%P")
           expect(page).to have_content(starts_at)
           expect(page).to have_text(event.host.name)
 


### PR DESCRIPTION
Thought it was a flaky test, but it's simply expecting `01 Apr at 8:54am` but we render `1 Apr at 8:54am`.

I fix the test, but it could also be the other way - so that the test is correct but the render needs fixing.

Up to you @thomascullen 