### PR TITLE
Add method for transferring user to a company

### DIFF
--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -119,7 +119,7 @@ class User < ApplicationRecord
   end
 
   # rubocop:disable Rails/SkipsModelValidations
-  def transfer_to_company(company, destroy: false)
+  def transfer_to_company!(company, destroy: false)
     ActiveRecord::Base.transaction do
       old_company_id = company_id
       raise "What are you even doing?" if old_company_id == company.id


### PR DESCRIPTION
Somewhat resolves: [PAIPAS#recEdBEVP1e2tMEWH](https://airtable.com/tblzKtqH2SVFDMJBw/viwbjBqy6YW12N7Rn/recEdBEVP1e2tMEWH?blocks=hide)

### Description

This should allow us to easily merge users on company.

First via console then, if it's useful, we can add it to admin/toby.

### Reviewer Checklist

- [x] PR has a clear title and description
- [ ] Manually tested the changes that the PR introduces
- [x] Changes introduced by the PR are covered by tests of acceptable quality
- [x] Checked the quality of [commit messages](http://chris.beams.io/posts/git-commit/)