### PR TITLE
Always return response object from onSubmit

### DIFF
--- a/app/javascript/guild/components/ComposerModal/EditGuildPost.js
+++ b/app/javascript/guild/components/ComposerModal/EditGuildPost.js
@@ -12,7 +12,7 @@ export default function EditGuildPost({ guildPost }) {
   const { denormalizedType: type, body, title, id } = guildPost;
 
   const handleUpdate = async (values) => {
-    const { errors } = await updateGuildPost({
+    const response = await updateGuildPost({
       variables: {
         input: {
           guildPostId: id,
@@ -20,8 +20,12 @@ export default function EditGuildPost({ guildPost }) {
         },
       },
     });
-    if (errors) return { errors };
-    navigate(`/composer/${id}/images`);
+
+    if (!response.errors) {
+      navigate(`/composer/${id}/images`);
+    }
+
+    return response;
   };
 
   return (


### PR DESCRIPTION
The `onSubmit` handle was only returning an { errors } object if there were any errors otherwise it returns undefined. This meant the `EditGuildPost` component was raising errors because it expects an object to be returned.

### Reviewer Checklist

- [ ] PR has a clear title and description
- [ ] Manually tested the changes that the PR introduces
- [ ] Changes introduced by the PR are covered by tests of acceptable quality
- [ ] Checked the quality of [commit messages](http://chris.beams.io/posts/git-commit/)