### PR TITLE
Require first_name and last_name when creating User for Company

### DIFF
--- a/spec/graphql/mutations/create_user_for_company_spec.rb
+++ b/spec/graphql/mutations/create_user_for_company_spec.rb
@@ -41,6 +41,29 @@ RSpec.describe Mutations::CreateUserForCompany do
     expect(ActionMailer::MailDeliveryJob).to have_been_enqueued.with("UserMailer", "invited_by_manager", "deliver_now", {args: [user, created_user]})
   end
 
+  context "when name is empty" do
+    let(:query) do
+      <<-GRAPHQL
+      mutation {
+        createUserForCompany(input: {
+          email: "#{email}"
+        }) {
+          user {
+            id
+          }
+        }
+      }
+      GRAPHQL
+    end
+
+    it "creates a new user on the company and sends an email to new user" do
+      response = AdvisableSchema.execute(query, context: context)
+      errors = response["errors"]
+      expect(errors.size).to eq(2)
+      expect(errors.map { |e| e["extensions"]["argumentName"] }).to match_array(%w[firstName lastName])
+    end
+  end
+
   context "when no team manager permission" do
     let(:user) { create(:user) }
 


### PR DESCRIPTION
All hell breaks loose when these are nil.

One example: https://sentry.io/organizations/advisable/issues/2340348570/?environment=production&project=2019647&referrer=alert_email

### Reviewer Checklist

- [ ] PR has a clear title and description
- [ ] Manually tested the changes that the PR introduces
- [ ] Changes introduced by the PR are covered by tests of acceptable quality
- [ ] Checked the quality of [commit messages](http://chris.beams.io/posts/git-commit/)
