### PR TITLE
Make zapier interactor action for importing Case Studies

### DIFF
--- a/app/lib/airtable/case_study.rb
+++ b/app/lib/airtable/case_study.rb
@@ -7,7 +7,7 @@ module Airtable
     self.base_key = ENV["AIRTABLE_DATABASE_KEY"]
     self.table_name = "Case Studies"
 
-    def import
+    def import!
       ActiveRecord::Base.transaction do
         article = ::CaseStudy::Article.find_or_initialize_by(airtable_id: id)
 
@@ -58,7 +58,8 @@ module Airtable
         end
 
         primary_skill = ::Skill.find_by!(airtable_id: fields["Primary Skill"].first)
-        article.skills.find_by(skill: primary_skill).update(primary: true)
+        article.skills.find_by(skill: primary_skill).update!(primary: true)
+        article
       end
     end
   end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -92,6 +92,7 @@ Rails.application.routes.draw do
   post 'zappier_interactor/create_magic_link'
   post 'zappier_interactor/enable_guild'
   post 'zappier_interactor/boost_guild_post'
+  post 'zappier_interactor/import_case_study'
 
   # match every other route to the frontend codebase
   root 'application#frontend'


### PR DESCRIPTION
Resolves:
[PAIPAS#recjzbQbBOfojXihe](https://airtable.com/tblzKtqH2SVFDMJBw/viwbjBqy6YW12N7Rn/recjzbQbBOfojXihe?blocks=hide)
[Case study Notion](https://www.notion.so/advisable/Case-study-management-45cb16746d86489783b422830d4f911a)

### Description

Last part of the case study Notion doc. 🥳

The only thing left for me to do is finishing the importer and polish on the fe branch - I expect us to work together on that.

### Reviewer Checklist

- [ ] PR has a clear title and description
- [ ] Manually tested the changes that the PR introduces
- [ ] Changes introduced by the PR are covered by tests of acceptable quality
- [ ] Checked the quality of [commit messages](http://chris.beams.io/posts/git-commit/)