### PR TITLE
Fixes the posts ordering for the story box

### DIFF
--- a/app/graphql/types/label_type.rb
+++ b/app/graphql/types/label_type.rb
@@ -20,7 +20,7 @@ module Types
     field :guild_posts, Types::Guild::PostInterface.connection_type, null: true, max_page_size: 5
 
     def guild_posts
-      object.guild_posts.published
+      object.guild_posts.published.order(created_at: :desc)
     end
   end
 end


### PR DESCRIPTION
Resolves: [Storybox posts are showing in reverse order](https://airtable.com/tblzKtqH2SVFDMJBw/viwNruI2lhO1UUmBo/rec8lzhYDzE62Ys3D?blocks=hide)

Note: Didn't use the `feed` scope because there might be a case where the pinned post has the same label which could interfere w/ the order.

### Reviewer Checklist

- [x] PR has a clear title and description
- [ ] Manually tested the changes that the PR introduces
- [ ] Changes introduced by the PR are covered by tests of acceptable quality
- [x] Checked the quality of [commit messages](http://chris.beams.io/posts/git-commit/)
