### PR TITLE
Improve toby login redirection

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -28,7 +28,7 @@ class ApplicationController < ActionController::Base
   def toby
     return if current_account&.admin?
 
-    redirect_to "/"
+    redirect_to(current_account ? "/" : "/login?redirect=/toby")
   end
 
   def client_ip


### PR DESCRIPTION
Before when you tried to visit /toby and you were not logged in it would redirect to the login page but after signing in you would instead be redirected to the /projects page rather than back to /toby. 

### Reviewer Checklist

- [ ] PR has a clear title and description
- [ ] Manually tested the changes that the PR introduces
- [ ] Changes introduced by the PR are covered by tests of acceptable quality
- [ ] Checked the quality of [commit messages](http://chris.beams.io/posts/git-commit/)
