### PR TITLE
Fix button text alignment

### DIFF
--- a/donut/src/components/Button/Button.stories.js
+++ b/donut/src/components/Button/Button.stories.js
@@ -15,7 +15,7 @@ export default {
 
 export const basic = () => {
   const label = text("Label", "Save Changes");
-  const size = select("Size", ["s", "m", "l"], "m");
+  const size = select("Size", ["xs", "s", "m", "l"], "m");
   const disabled = boolean("Disabled", false);
   const loading = boolean("Loading", false);
   const variant = select("Variant", Object.keys(VARIANTS), "primary");

--- a/donut/src/components/Button/styles.js
+++ b/donut/src/components/Button/styles.js
@@ -140,7 +140,8 @@ const buttonSize = variant({
   prop: "buttonSize",
   variants: {
     xs: {
-      height: 28,
+      height: "28px",
+      lineHeight: "28px",
       fontSize: 14,
       fontWeight: 500,
       paddingLeft: 3,
@@ -157,11 +158,12 @@ const buttonSize = variant({
       },
     },
     s: {
-      height: 35,
-      fontSize: 15,
+      height: "36px",
+      lineHeight: "36px",
+      fontSize: 16,
       fontWeight: 500,
-      paddingLeft: 18,
-      paddingRight: 18,
+      paddingLeft: "20px",
+      paddingRight: "20px",
       svg: {
         width: 16,
         height: 16,
@@ -174,11 +176,12 @@ const buttonSize = variant({
       },
     },
     m: {
-      height: 42,
+      height: "40px",
       fontSize: 17,
+      lineHeight: "40px",
       fontWeight: 500,
-      paddingLeft: 24,
-      paddingRight: 24,
+      paddingLeft: "24px",
+      paddingRight: "24px",
       svg: {
         width: 20,
         height: 20,
@@ -191,8 +194,9 @@ const buttonSize = variant({
       },
     },
     l: {
-      height: 50,
+      height: "48px",
       fontSize: 18,
+      lineHeight: "48px",
       fontWeight: 500,
       paddingLeft: 24,
       paddingRight: 24,

--- a/package.json
+++ b/package.json
@@ -127,7 +127,7 @@
     "test:parallel": "jest",
     "test:debug": "node --inspect-brk node_modules/jest/bin/jest.js --runInBand --watch",
     "lint": "eslint app/javascript",
-    "storybook": "start-storybook -p 6006 -c donut/.storybook",
+    "storybook": "start-storybook -p 6006 -c donut/.storybook -s ./public",
     "build-storybook": "build-storybook -c donut/.storybook"
   },
   "lint-staged": {


### PR DESCRIPTION
This has been driving me crazy for a while but since switching to TT hoves our button text has not been vertically aligned correctly. I also took the opportunity to revise the button sizes and make sure they fit into 4px baseline grid.

Before
![Screenshot 2021-04-29 at 17 49 42](https://user-images.githubusercontent.com/1512593/116588901-fed86780-a913-11eb-9871-46b7fcf2f9b8.png)

After
![Screenshot 2021-04-29 at 17 49 31](https://user-images.githubusercontent.com/1512593/116588928-0435b200-a914-11eb-9e55-955625a08d2a.png)


### Reviewer Checklist

- [ ] PR has a clear title and description
- [ ] Manually tested the changes that the PR introduces
- [ ] Changes introduced by the PR are covered by tests of acceptable quality
- [ ] Checked the quality of [commit messages](http://chris.beams.io/posts/git-commit/)