### PR TITLE
Fixes webkit line clamp for events list

### DIFF
--- a/app/javascript/guild/views/Event/index.js
+++ b/app/javascript/guild/views/Event/index.js
@@ -90,12 +90,13 @@ const Event = () => {
           <HourDateTag mb="2" date={event.startsAt} />
           <StyledLineClamp
             lines={2}
-            size="38px"
+            fontSize="38px"
             color="blue900"
             lineHeight="120%"
             fontWeight="semibold"
             letterSpacing="-0.02em"
             mb="7"
+            as={Text}
           >
             {event.title}
           </StyledLineClamp>

--- a/app/javascript/guild/views/Events/components/EventsList/Event.js
+++ b/app/javascript/guild/views/Events/components/EventsList/Event.js
@@ -1,7 +1,7 @@
 import React from "react";
 import { useHistory } from "react-router-dom";
 import ReactMarkdown from "react-markdown";
-import { Box } from "@advisable/donut";
+import { Box, Text } from "@advisable/donut";
 import { CoverImage } from "@guild/components/CoverImage";
 import StartsAtTag from "@guild/components/Event/StartsAtTag";
 import HostDetails from "@guild/components/Event/HostDetails";
@@ -61,6 +61,8 @@ export default function Event({ event }) {
           marginTop="3"
           lineHeight="1.3"
           color="neutral700"
+          height="64px"
+          as={Text}
         >
           <ReactMarkdown>{event.description}</ReactMarkdown>
         </StyledLineClamp>

--- a/app/javascript/guild/views/Events/components/FeaturedEvent/index.js
+++ b/app/javascript/guild/views/Events/components/FeaturedEvent/index.js
@@ -1,5 +1,5 @@
 import React from "react";
-import { Box } from "@advisable/donut";
+import { Box, Text } from "@advisable/donut";
 import { useHistory } from "react-router-dom";
 import { CoverImage } from "@guild/components/CoverImage";
 import StartsAtTag from "@guild/components/Event/StartsAtTag";
@@ -57,18 +57,13 @@ export default function FeaturedEvent({ event }) {
               fontWeight="600"
               color="neutral900"
               letterSpacing="-0.05rem"
+              as={Text}
             >
               {event.title}
             </StyledLineClamp>
           </Box>
           <Box marginBottom={12}>
-            <Markdown
-              as={StyledLineClamp}
-              size="l"
-              lineHeight="l"
-              color="neutral900"
-              lines={3}
-            >
+            <Markdown as={StyledLineClamp} height="72px" lines={3}>
               {event.description}
             </Markdown>
           </Box>

--- a/app/javascript/guild/views/Events/styles.js
+++ b/app/javascript/guild/views/Events/styles.js
@@ -1,7 +1,7 @@
 import styled from "styled-components";
-import { Text, Card } from "@advisable/donut";
+import { Card, Box } from "@advisable/donut";
 
-export const StyledLineClamp = styled(Text)`
+export const StyledLineClamp = styled(Box)`
   display: -webkit-box;
   -webkit-line-clamp: ${({ lines }) => lines || 2};
   -webkit-box-orient: vertical;


### PR DESCRIPTION
### Description

Fixes an issue Annie reported [on slack](https://advisable.slack.com/archives/C0185EXSCN6/p1619615743138200) a few days ago w/ the events list page.  I was able to reproduce this w/ firefox 88.0

Texted fix on both chrome and ff across breakpoints

### Reviewer Checklist

- [x] PR has a clear title and description
- [ ] Manually tested the changes that the PR introduces
- [ ] Changes introduced by the PR are covered by tests of acceptable quality
- [x] Checked the quality of [commit messages](http://chris.beams.io/posts/git-commit/)
