### PR TITLE
Allow uploads when file extension is uppercase

### DIFF
--- a/app/javascript/src/utilities/matchFileType.js
+++ b/app/javascript/src/utilities/matchFileType.js
@@ -1,7 +1,7 @@
 export default function matchFileType(files, accept) {
   const isMatch = files.every(({ name }) => {
     const type = name.split(".").pop();
-    return accept.includes(type);
+    return accept.toLowerCase().includes(type?.toLowerCase());
   });
   return isMatch;
 }


### PR DESCRIPTION
Resolves: [Ticket](https://airtable.com/tblzKtqH2SVFDMJBw/viweflCthZ8xQiFla/recRf4KHG27tyynas?blocks=hide)

### Description

The file type restriction was preventing the user from selecting files where the file extension was uppercase. e.g image.JPG. This change allows both upper and lowercase extensions by forcing everything to lowercase when checking.

### Reviewer Checklist

- [ ] PR has a clear title and description
- [ ] Manually tested the changes that the PR introduces
- [ ] Changes introduced by the PR are covered by tests of acceptable quality
- [ ] Checked the quality of [commit messages](http://chris.beams.io/posts/git-commit/)
