### PR TITLE
Removes event attendees counter

### DIFF
--- a/app/graphql/types/event_type.rb
+++ b/app/graphql/types/event_type.rb
@@ -2,6 +2,8 @@
 
 module Types
   class EventType < Types::BaseType
+    description "Fields representing an Event"
+
     field :title, String, null: false
     field :description, String, null: false
     field :color, String, null: false
@@ -10,25 +12,21 @@ module Types
     field :ends_at, GraphQL::Types::ISO8601DateTime, null: false
     field :created_at, GraphQL::Types::ISO8601DateTime, null: false
     field :host, Types::SpecialistType, null: false
-    field :attendees_count, Integer, null: false
     field :attendees, Types::SpecialistType.connection_type, null: false
 
-    field :id, ID, null: false
+    field :id, ID, null: false, method: :uid
 
-    def id
-      object.uid
-    end
-
-    field :cover_photo_url, String, null: true
-
-    def cover_photo_url
-      object.resized_cover_photo_url
-    end
+    field :cover_photo_url, String, null: true, method: :resized_cover_photo_url
 
     field :attending, Boolean, null: false
 
     def attending
       object.attendees.exists?(current_user.id)
+    end
+
+    field :attendees_count, Integer, null: false
+    def attendees_count
+      object.attendees.count
     end
 
     field :published, Boolean, null: false

--- a/app/models/event.rb
+++ b/app/models/event.rb
@@ -54,20 +54,19 @@ end
 #
 # Table name: events
 #
-#  id              :bigint           not null, primary key
-#  attendees_count :integer          default(0)
-#  color           :string           not null
-#  description     :text             not null
-#  ends_at         :datetime
-#  featured        :boolean          default(FALSE)
-#  published_at    :datetime
-#  starts_at       :datetime
-#  title           :string           not null
-#  uid             :string           not null
-#  url             :string
-#  created_at      :datetime         not null
-#  updated_at      :datetime         not null
-#  host_id         :bigint
+#  id           :bigint           not null, primary key
+#  color        :string           not null
+#  description  :text             not null
+#  ends_at      :datetime
+#  featured     :boolean          default(FALSE)
+#  published_at :datetime
+#  starts_at    :datetime
+#  title        :string           not null
+#  uid          :string           not null
+#  url          :string
+#  created_at   :datetime         not null
+#  updated_at   :datetime         not null
+#  host_id      :bigint
 #
 # Indexes
 #

--- a/app/models/event_attendee.rb
+++ b/app/models/event_attendee.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 class EventAttendee < ApplicationRecord
-  belongs_to :event, counter_cache: :attendees_count
+  belongs_to :event
   belongs_to :attendee, class_name: 'Specialist', foreign_key: 'specialist_id', inverse_of: :event_attendees
 
   validates :attendee, uniqueness: {

--- a/db/migrate/20210506170379_remove_attendees_count_from_events.rb
+++ b/db/migrate/20210506170379_remove_attendees_count_from_events.rb
@@ -1,0 +1,9 @@
+# frozen_string_literal: true
+
+class RemoveAttendeesCountFromEvents < ActiveRecord::Migration[6.1]
+  def change
+    safety_assured do
+      remove_column :events, :attendees_count, :integer
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -390,7 +390,6 @@ ActiveRecord::Schema.define(version: 2021_05_07_065127) do
     t.string "url"
     t.string "color", null: false
     t.bigint "host_id"
-    t.integer "attendees_count", default: 0
     t.boolean "featured", default: false
     t.datetime "published_at"
     t.datetime "starts_at"

--- a/spec/graphql/mutations/update_event_registration_spec.rb
+++ b/spec/graphql/mutations/update_event_registration_spec.rb
@@ -34,7 +34,7 @@ RSpec.describe Mutations::UpdateEventRegistration do
         update_event_registration
         event.reload
       end.to change(EventAttendee, :count).from(0).to(1).
-        and change(event, :attendees_count).from(0).to(1)
+        and change(event.attendees, :count).from(0).to(1)
     end
 
     it "does not register the current_user of they are already registered" do
@@ -43,7 +43,7 @@ RSpec.describe Mutations::UpdateEventRegistration do
       expect do
         update_event_registration
         event.reload
-      end.not_to change(event, :attendees_count)
+      end.to change(event, :event_attendees)
     end
 
     it "returns an event and whether current user is attending" do
@@ -85,7 +85,7 @@ RSpec.describe Mutations::UpdateEventRegistration do
       expect do
         update_event_registration
         event.reload
-      end.to change(event, :attendees_count).from(1).to(0)
+      end.to change(event.event_attendees, :count).from(1).to(0)
     end
 
     it "shows the viewer as not attending" do

--- a/spec/models/event_spec.rb
+++ b/spec/models/event_spec.rb
@@ -12,7 +12,6 @@ RSpec.describe Event, type: :model do
     it { expect(event).to have_db_column :description }
     it { expect(event).to have_db_column :starts_at }
     it { expect(event).to have_db_column :ends_at }
-    it { expect(event).to have_db_column :attendees_count }
     it { expect(event).to have_db_column :published_at }
     it { expect(event).to have_db_column :url }
     it { expect(event).to have_db_column :featured }
@@ -32,15 +31,6 @@ RSpec.describe Event, type: :model do
     expect do
       event.update!(ends_at: Time.zone.at(0))
     end.to raise_error(ActiveRecord::RecordInvalid).with_message(/Ends at must be after starts_at/)
-  end
-
-  it "has a counter for event attendees" do
-    event.save!
-
-    expect do
-      event.event_attendees.create(attendee: create(:specialist))
-      event.reload
-    end.to change(event, :attendees_count).from(0).to(1)
   end
 
   describe "with upcoming" do

--- a/spec/system/events_spec.rb
+++ b/spec/system/events_spec.rb
@@ -27,7 +27,7 @@ RSpec.describe 'Events view', type: :system do
       event.attendees << specialist
       visit "/guild/events"
       expect(page).to have_content("Attending")
-      expect(page).to have_content("#{event.reload.attendees_count} Attending")
+      expect(page).to have_content("#{event.attendees.count} Attending")
     end
   end
 end


### PR DESCRIPTION
Resolves: [slack thread](https://advisable.slack.com/archives/G01JQTHJZQX/p1620319428009500)

### Description

Event attendees are being manually added to the db and as a result the counter isn't changed.

### Reviewer Checklist

- [x] PR has a clear title and description
- [ ] Manually tested the changes that the PR introduces
- [x] Changes introduced by the PR are covered by tests of acceptable quality
- [x] Checked the quality of [commit messages](http://chris.beams.io/posts/git-commit/)