### PR TITLE
Stop syncing company name

### DIFF
--- a/app/lib/airtable/client_contact.rb
+++ b/app/lib/airtable/client_contact.rb
@@ -43,7 +43,6 @@ module Airtable
         user.company.update(sales_person: sales_person)
       end
 
-      user.company.name = self['Company Name'].try(:first)
       industry_id = self['Industry'].try(:first)
       if industry_id
         industry = ::Industry.find_by_airtable_id(industry_id)
@@ -93,7 +92,6 @@ module Airtable
       self['RID'] = user.rid
       self['gclid'] = user.gclid
       self['fid'] = user.fid
-      self['Company Name'] = user.company.name
       self['City'] = user.company.address.try(:[], 'city')
       self['Application Reminder At'] = user.application_reminder_at
       self['Contact Status'] = user.contact_status


### PR DESCRIPTION
Resolves: #1163 

### Description

We weren’t syncing “Company Name” before and I thought it was an overlook. apparently it was on purpose.

"Company Name" is a computed field from a Client table and we removed Client table
from our app.

### Reviewer Checklist

- [ ] PR has a clear title and description
- [ ] Manually tested the changes that the PR introduces
- [ ] Changes introduced by the PR are covered by tests of acceptable quality
- [ ] Checked the quality of [commit messages](http://chris.beams.io/posts/git-commit/)
