### PR TITLE
Add zappier interactor action for updating interview status

### DIFF
--- a/app/controllers/zappier_interactor_controller.rb
+++ b/app/controllers/zappier_interactor_controller.rb
@@ -32,6 +32,16 @@ class ZappierInteractorController < ApplicationController
     render json: {error: "Validation failed", message: e.message}, status: :unprocessable_entity
   end
 
+  def update_interview
+    interview = Interview.find_by!(uid: params[:uid])
+    interview.update!(status: params[:status])
+    render json: {status: "OK.", uid: interview.uid}
+  rescue ActiveRecord::RecordNotFound
+    render json: {error: "Interview not found"}, status: :unprocessable_entity
+  rescue ActiveRecord::RecordInvalid => e
+    render json: {error: "Validation failed", message: e.message}, status: :unprocessable_entity
+  end
+
   def attach_previous_project_image
     previous_project = PreviousProject.find_by!(uid: params[:uid])
     raise ActiveRecord::RecordNotFound if params[:image_url].blank?

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -87,8 +87,10 @@ Rails.application.routes.draw do
   get 'accounts/me'
   post 'accounts/user'
   post 'accounts/specialist'
+
   post 'zappier_interactor/create_application'
   post 'zappier_interactor/update_application'
+  post 'zappier_interactor/update_interview'
   post 'zappier_interactor/attach_previous_project_image'
   post 'zappier_interactor/create_magic_link'
   post 'zappier_interactor/enable_guild'


### PR DESCRIPTION
Resolves: 
Prerequisite for #1171
Resolves parts of:
[PAIPAS#recJSw22aOMRxgInu](https://airtable.com/tblzKtqH2SVFDMJBw/viwbjBqy6YW12N7Rn/recJSw22aOMRxgInu?blocks=hide)
[Notion](https://www.notion.so/advisable/Remove-interview-syncing-from-Airtable-cfd51d0c441d438aaf7c10bd493a67cc)

### Description

Interactor zap action is already set up for the production env, since it worked flawlessly locally:
https://developer.zapier.com/app/119254/version/1.0.0/actions/creates/update_interview/api#testSetup

### Reviewer Checklist

- [x] PR has a clear title and description
- [ ] Manually tested the changes that the PR introduces
- [x] Changes introduced by the PR are covered by tests of acceptable quality
- [x] Checked the quality of [commit messages](http://chris.beams.io/posts/git-commit/)
