### PR TITLE
Fixes sticky register section and event list card width for mobile

### DIFF
--- a/app/javascript/guild/views/Event/index.js
+++ b/app/javascript/guild/views/Event/index.js
@@ -30,7 +30,7 @@ const Event = () => {
   const viewer = useViewer();
   const theme = useTheme();
   const sUp = useBreakpoint("sUp");
-  const detailsRef = React.useRef(null);
+  const detailsRef = useRef(null);
 
   const { data, loading } = useQuery(EVENT_QUERY, {
     variables: { id: eventId },

--- a/app/javascript/guild/views/Events/components/EventsList/Event.js
+++ b/app/javascript/guild/views/Events/components/EventsList/Event.js
@@ -21,6 +21,7 @@ export default function Event({ event }) {
     <StyledEventCard
       flex="auto"
       height="510px"
+      minWidth="0"
       key={event.id}
       borderRadius="12px"
       position="relative"


### PR DESCRIPTION
Resolves: 

* [Broken view for Mobile Version in the Event section](https://airtable.com/tblzKtqH2SVFDMJBw/viwNruI2lhO1UUmBo/recjwd3kMhW6swYx2?blocks=hide)
* [Attendees overflowed the Host card on Mac 13"](https://airtable.com/tblzKtqH2SVFDMJBw/viwNruI2lhO1UUmBo/rechHIgDagIPgxJXp?blocks=hide)

### Reviewer Checklist

- [ ] PR has a clear title and description
- [ ] Manually tested the changes that the PR introduces
- [ ] Changes introduced by the PR are covered by tests of acceptable quality
- [ ] Checked the quality of [commit messages](http://chris.beams.io/posts/git-commit/)

### Screenshots

* Broken view for Mobile Version in the Event section
<img width="237" alt="Screen Shot 2021-05-19 at 7 27 01 PM" src="https://user-images.githubusercontent.com/34672/118909973-a7a53180-b8d8-11eb-8c69-d4dab6a1b91b.png">

