### PR TITLE
Create new array instead of mutating existing one

### DIFF
--- a/app/graphql/mutations/case_study/archive_search_article.rb
+++ b/app/graphql/mutations/case_study/archive_search_article.rb
@@ -26,7 +26,7 @@ module Mutations
         search = ::CaseStudy::Search.find_by!(uid: search)
         article = ::CaseStudy::Article.find_by!(uid: article)
 
-        search.archived << article.id
+        search.archived = search.archived + [article.id]
 
         if args[:feedback]
           ::CaseStudy::SearchFeedback.create!(

--- a/app/graphql/mutations/case_study/save_search_article.rb
+++ b/app/graphql/mutations/case_study/save_search_article.rb
@@ -25,7 +25,7 @@ module Mutations
         search = ::CaseStudy::Search.find_by!(uid: search)
         article = ::CaseStudy::Article.find_by!(uid: article)
 
-        search.saved << article.id
+        search.saved = search.saved + [article.id]
 
         current_account_responsible_for do
           search.save


### PR DESCRIPTION
### Description

Create new array instead of mutating existing one

Because you might be editing an array that's not the attribute.

### Reviewer Checklist

- [ ] PR has a clear title and description
- [ ] Manually tested the changes that the PR introduces
- [ ] Changes introduced by the PR are covered by tests of acceptable quality
- [ ] Checked the quality of [commit messages](http://chris.beams.io/posts/git-commit/)