### PR TITLE
Freelancing empty data

### DIFF
--- a/app/javascript/src/views/FreelancerProfile/index.js
+++ b/app/javascript/src/views/FreelancerProfile/index.js
@@ -29,8 +29,8 @@ function FreelancerProfile() {
   });
   useInitialScroll(data);
 
+  if (loading) return <Loading />;
   if (isNotFound(error)) return <NotFound />;
-  if (loading || !data) return <Loading />;
 
   return (
     <Box


### PR DESCRIPTION
Resolves: [Ticket](URL)

### Description

As we discovered before if a user cancels a request ( or if it fails ) `loading` can be set to false without any data being set. In these cases Apollo throws a network error. This sets up the RetryLink in the Apollo client as suggested by Apollo to handle network errors. This should fix our issue. 🤷‍♂️ 

https://www.apollographql.com/docs/react/data/error-handling/#on-network-errors

### Reviewer Checklist

- [ ] PR has a clear title and description
- [ ] Manually tested the changes that the PR introduces
- [ ] Changes introduced by the PR are covered by tests of acceptable quality
- [ ] Checked the quality of [commit messages](http://chris.beams.io/posts/git-commit/)
