### PR TITLE
Fix bug when removing all previous project images

### DIFF
--- a/app/javascript/src/components/PreviousProjectFormModal/ImageTiles.js
+++ b/app/javascript/src/components/PreviousProjectFormModal/ImageTiles.js
@@ -196,7 +196,9 @@ function ImageTiles({
 
         if (image.cover) {
           const nextCover = images.filter((i) => i.id !== image.id)[0];
-          updateCoverInCache(nextCover);
+          if (nextCover) {
+            updateCoverInCache(nextCover);
+          }
         }
       }
     },


### PR DESCRIPTION
Resolves: [Ticket](https://sentry.io/organizations/advisable/issues/2415787670/?project=2019647&query=is%3Aunresolved&statsPeriod=14d)

### Description

When removing a project image that is currently set to the cover photo we search for the first image in the stack and set that as the cover image instead. This was causing an error when removing all of the images because there was no more images left to set the cover photo to.

### Manual Testing Instructions

Steps:
1. Upload a few images
2. Remove all of them

### Reviewer Checklist

- [ ] PR has a clear title and description
- [ ] Manually tested the changes that the PR introduces
- [ ] Changes introduced by the PR are covered by tests of acceptable quality
- [ ] Checked the quality of [commit messages](http://chris.beams.io/posts/git-commit/)