### PR TITLE
Changes event page to be public

### DIFF
--- a/app/graphql/types/event_type.rb
+++ b/app/graphql/types/event_type.rb
@@ -21,6 +21,8 @@ module Types
     field :attending, Boolean, null: false
 
     def attending
+      return false if current_user.blank?
+
       object.attendees.exists?(current_user.id)
     end
 

--- a/app/graphql/types/query_type.rb
+++ b/app/graphql/types/query_type.rb
@@ -216,7 +216,6 @@ module Types
     end
 
     def event(id:)
-      requires_guild_user!
       ::Event.find_by!(uid: id)
     end
 

--- a/app/javascript/guild/App.js
+++ b/app/javascript/guild/App.js
@@ -79,11 +79,7 @@ const App = () => {
                   component={Feed}
                 />
                 <AuthenticatedRoute exact path="/follows" component={Follows} />
-                <AuthenticatedRoute
-                  exact
-                  path="/events/:eventId"
-                  component={Event}
-                />
+                <Route exact path="/events/:eventId" component={Event} />
                 <AuthenticatedRoute exact path="/events" component={Events} />
               </Switch>
             </Suspense>

--- a/app/javascript/guild/views/Event/index.js
+++ b/app/javascript/guild/views/Event/index.js
@@ -1,6 +1,6 @@
 import React, { useLayoutEffect, useRef } from "react";
 import { useQuery, useMutation } from "@apollo/client";
-import { useParams } from "react-router-dom";
+import { useParams, useLocation } from "react-router-dom";
 import Sticky from "react-stickynode";
 import { Text, Box, useTheme, useBreakpoint } from "@advisable/donut";
 import useViewer from "@advisable-main/hooks/useViewer";
@@ -22,6 +22,7 @@ import HostBio from "./components/HostBio";
 import DetailsAside from "./components/DetailsAside";
 import RegisterButton from "./components/RegisterButton";
 import StatusNotice from "./components/StatusNotice";
+import { loginWithRedirectPath } from "@guild/utils";
 
 const Event = () => {
   useScrollToTop();
@@ -31,6 +32,7 @@ const Event = () => {
   const theme = useTheme();
   const sUp = useBreakpoint("sUp");
   const detailsRef = useRef(null);
+  const location = useLocation();
 
   const { data, loading } = useQuery(EVENT_QUERY, {
     variables: { id: eventId },
@@ -46,6 +48,8 @@ const Event = () => {
   );
 
   const handleEventRegistration = () => {
+    if (!viewer) return loginWithRedirectPath(location.pathname);
+
     const inProgress = eventStatus === EventStatus.inProgress;
     const joinEvent = () => window.open(event.url, "JoinEvent");
     if (inProgress && event.attending) return joinEvent();


### PR DESCRIPTION
Resolves: [Make the link to the event public](https://airtable.com/tblzKtqH2SVFDMJBw/viwNruI2lhO1UUmBo/rec37bOrzLqSWE6fa?blocks=hide)

* Changes event pages to be public.  If the viewer is not logged in they're redirected to the login page ( w/ signup option ) similar to what's setup for shareable guild posts.

### Reviewer Checklist

- [x] PR has a clear title and description
- [x] Manually tested the changes that the PR introduces
- [x] Changes introduced by the PR are covered by tests of acceptable quality
- [x] Checked the quality of [commit messages](http://chris.beams.io/posts/git-commit/)
