### PR TITLE
Add input for toby Date attribute types

### DIFF
--- a/app/javascript/src/components/DatePicker/index.js
+++ b/app/javascript/src/components/DatePicker/index.js
@@ -1,6 +1,6 @@
 import React from "react";
 import { DateTime } from "luxon";
-import { Input, Card } from "@advisable/donut";
+import { Input, Card, Button } from "@advisable/donut";
 import { usePopoverState, Popover, PopoverDisclosure } from "reakit/Popover";
 import DayPicker from "react-day-picker";
 import "react-day-picker/lib/style.css";
@@ -19,6 +19,7 @@ DatePicker.Input = function DatePickerInput({
   disabledDays,
   label,
   onChange,
+  clearable,
   ...props
 }) {
   const popover = usePopoverState({ placement: "bottom-start", gutter: 0 });
@@ -28,11 +29,10 @@ DatePicker.Input = function DatePickerInput({
     popover.hide();
   };
 
-  // useEffect(() => {
-  //   if (!popover.visible) {
-  //     onBlur();
-  //   }
-  // }, [popover, onBlur]);
+  const handleClear = () => {
+    onChange(null);
+    popover.hide();
+  };
 
   const selected = props.value && DateTime.fromISO(props.value);
   const inputValue = selected
@@ -62,6 +62,17 @@ DatePicker.Input = function DatePickerInput({
             disabledDays={disabledDays}
             onDayClick={handleSelection}
           />
+          {clearable && (
+            <Button
+              size="xs"
+              marginTop={2}
+              type="button"
+              variant="minimal"
+              onClick={handleClear}
+            >
+              Clear date
+            </Button>
+          )}
         </Card>
       </Popover>
     </>

--- a/app/javascript/toby/attributes/date.js
+++ b/app/javascript/toby/attributes/date.js
@@ -1,9 +1,38 @@
 import React from "react";
 import { DateTime } from "luxon";
+import { useField } from "formik";
+import DatePicker from "src/components/DatePicker";
+
+function DateAttribute({ record, field }) {
+  const value = record[field.name];
+  return value ? DateTime.fromISO(value).toLocaleString() : null;
+}
+
+function DateInput({ attribute }) {
+  const [field, meta, { setValue }] = useField(attribute.name);
+
+  const error = meta.touched && meta.error;
+
+  const handleChange = (date) => {
+    setValue(date);
+  };
+
+  return (
+    <DatePicker.Input
+      size="sm"
+      clearable
+      error={error}
+      label="Select date"
+      value={field.value}
+      onChange={handleChange}
+    />
+  );
+}
 
 export default {
-  render: function RenderDate({ record, field }) {
-    const value = record[field.name];
-    return value ? DateTime.fromISO(value).toLocaleString() : null;
+  render: DateAttribute,
+  input: DateInput,
+  initializeFormValue(record, attribute) {
+    return record[attribute.name] || null;
   },
 };

--- a/app/lib/toby/resources/specialist.rb
+++ b/app/lib/toby/resources/specialist.rb
@@ -7,16 +7,13 @@ module Toby
       attribute :uid, Attributes::String, readonly: true
       attribute :email, Lookups::Accounts::Email
       attribute :application_stage, Attributes::Select, options: ::Specialist::VALID_APPLICATION_STAGES
-      attribute :previous_projects, Attributes::HasMany
       attribute :account, Attributes::BelongsTo
       attribute :bio, Attributes::LongText
       attribute :linkedin, Attributes::String
       attribute :website, Attributes::String
       attribute :hourly_rate, Attributes::Currency
       attribute :country, Attributes::BelongsTo
-      attribute :applications, Attributes::HasMany
       attribute :skills, Attributes::HasManyThrough
-      attribute :reviews, Attributes::HasMany
       attribute :unavailable_until, Attributes::Date
       attribute :created_at, Attributes::DateTime, readonly: true
       attribute :updated_at, Attributes::DateTime, readonly: true


### PR DESCRIPTION
### Description

Adds an input for toby "Date" attributes. This only covers "Date" attributes and not "DateTime" attributes, i'l do another PR for that.

I have also included in this some changes to the specialists resource. I have removed the 'applications', 'previous_projects' and 'reviews' columns. My reason for doing so is that these mostly add clutter to the specialist resource views. If we need to find or modify any of these resources it can and should be done from their own toby resource views. I'd say this will likely apply to the majority of "has_many" relationships.

### Reviewer Checklist

- [x] PR has a clear title and description
- [x] Manually tested the changes that the PR introduces
- [ ] Changes introduced by the PR are covered by tests of acceptable quality
- [ ] Checked the quality of [commit messages](http://chris.beams.io/posts/git-commit/)