### PR TITLE
Fix bug preventing user from scrolling when filters open

### DIFF
--- a/app/javascript/toby/styles.js
+++ b/app/javascript/toby/styles.js
@@ -38,7 +38,8 @@ export const StyledViewport = styled.div`
 
 export const StyledScrollContainer = styled.div`
   height: 100%;
-  min-width: 100vw;
+  min-width: 0;
+  width: ${(p) => (p.$filterOpen ? "calc(100vw - 400px)" : "100vw")};
   overflow-y: scroll;
 `;
 

--- a/app/javascript/toby/views/resource/index.js
+++ b/app/javascript/toby/views/resource/index.js
@@ -131,6 +131,7 @@ function Resource({ resource, views }) {
         <StyledScrollContainer
           ref={scrollRef}
           as={motion.div}
+          $filterOpen={isOpen}
           transition={{ duration: 0.2 }}
           animate={{ x: isOpen ? 400 : 0 }}
         >


### PR DESCRIPTION
Currently when the filter drawer is open the user cant scroll all the way to the right to see the last two columns. This PR fixes that by reducing the viewport width when the filters drawer is open.

### Reviewer Checklist

- [ ] PR has a clear title and description
- [ ] Manually tested the changes that the PR introduces
- [ ] Changes introduced by the PR are covered by tests of acceptable quality
- [ ] Checked the quality of [commit messages](http://chris.beams.io/posts/git-commit/)