### PR TITLE
We no longer have object

### DIFF
--- a/app/jobs/resize_image_job.rb
+++ b/app/jobs/resize_image_job.rb
@@ -6,6 +6,6 @@ class ResizeImageJob < ApplicationJob
   def perform(attachment, **options)
     attachment.variant(options).processed
   rescue MiniMagick::Error => e
-    Sentry.capture_exception(e, level: 'debug', extra: {object_class: object.class.name, object_id: object.id, name: attachment_name})
+    Sentry.capture_exception(e, level: 'debug', extra: {attachment_id: attachment.id, record_type: attachment.record_type, record_id: attachment.record_id})
   end
 end


### PR DESCRIPTION
Resolves: #1221

### Description

Since https://github.com/advisablecom/Advisable/commit/cb2422b0a9755d7a2d0cef1d5466c9961d02a606 we no longer have `object`. And not only did I not notice that when migrating, I missed it again in #1204 😂

Anyway, this should do it now.

### Reviewer Checklist

- [ ] PR has a clear title and description
- [ ] Manually tested the changes that the PR introduces
- [ ] Changes introduced by the PR are covered by tests of acceptable quality
- [ ] Checked the quality of [commit messages](http://chris.beams.io/posts/git-commit/)