### PR TITLE
Change badge to display upcoming events count

### DIFF
--- a/app/graphql/types/event_connection.rb
+++ b/app/graphql/types/event_connection.rb
@@ -5,9 +5,14 @@ module Types
     edge_type(Types::EventEdge)
     description "Relay connection type for event items"
 
-    field :total_count, Integer, null: false, deprecation_reason: "We no longer need the total number of upcoming and ended events"
+    field :total_count, Integer, null: false, deprecation_reason: "We only display the number of upcoming events"
     def total_count
       object.items&.size
+    end
+
+    field :upcoming_events_count, Integer, null: false
+    def upcoming_events_count
+      object.items&.upcoming&.size
     end
   end
 end

--- a/app/graphql/types/query_type.rb
+++ b/app/graphql/types/query_type.rb
@@ -211,11 +211,6 @@ module Types
       ::Event.list
     end
 
-    field :upcoming_events_count, Integer, null: true
-    def upcoming_events_count
-      ::Event.upcoming.count
-    end
-
     field :event, Types::EventType, null: true do
       argument :id, ID, required: true
     end

--- a/app/javascript/guild/components/Header/index.js
+++ b/app/javascript/guild/components/Header/index.js
@@ -17,7 +17,8 @@ import {
   StyledHeaderBadgeNumber,
   StyledHamburger,
 } from "./styles";
-import { GUILD_LAST_READ_QUERY, UPCOMING_EVENTS_COUNT } from "./queries";
+import { GUILD_LAST_READ_QUERY } from "./queries";
+import { EVENTS_QUERY } from "@guild/views/Events/queries";
 import Notifications from "./Notifications";
 import { useTwilioChat } from "../TwilioProvider";
 
@@ -37,10 +38,8 @@ const Header = () => {
   });
   const hasUnreadNotifications = lastReadData?.viewer?.guildUnreadNotifications;
 
-  const { data: eventsData } = useQuery(UPCOMING_EVENTS_COUNT, {
-    skip: !viewer,
-  });
-  const eventsCount = eventsData?.upcomingEventsCount;
+  const { data: eventsData } = useQuery(EVENTS_QUERY, { skip: !viewer });
+  const eventsCount = eventsData?.events?.upcomingEventsCount;
 
   return (
     <>

--- a/app/javascript/guild/components/Header/queries.js
+++ b/app/javascript/guild/components/Header/queries.js
@@ -11,12 +11,6 @@ export const GUILD_LAST_READ_QUERY = gql`
   }
 `;
 
-export const UPCOMING_EVENTS_COUNT = gql`
-  {
-    upcomingEventsCount
-  }
-`;
-
 export const LOGOUT = gql`
   mutation logout($input: LogoutInput!) {
     logout(input: $input) {

--- a/app/javascript/guild/views/Events/queries.js
+++ b/app/javascript/guild/views/Events/queries.js
@@ -6,6 +6,7 @@ export const EVENTS_QUERY = gql`
 
   query events($cursor: String) {
     events(first: 7, after: $cursor) {
+      upcomingEventsCount
       pageInfo {
         endCursor
         hasNextPage

--- a/app/models/event.rb
+++ b/app/models/event.rb
@@ -30,7 +30,7 @@ class Event < ApplicationRecord
     published.order(featured: :desc, starts_at: :desc)
   }
   scope :upcoming, lambda {
-    list.where(ends_at: (Time.zone.now..))
+    where(ends_at: (Time.zone.now..))
   }
 
   private


### PR DESCRIPTION
Resolves: [Events notification should only show the number of upcoming events](https://airtable.com/tblzKtqH2SVFDMJBw/viwNruI2lhO1UUmBo/rectvmRmNZVhbOXWb?blocks=hide)

### Reviewer Checklist

- [x] PR has a clear title and description
- [x] Manually tested the changes that the PR introduces
- [x] Changes introduced by the PR are covered by tests of acceptable quality
- [x] Checked the quality of [commit messages](http://chris.beams.io/posts/git-commit/)

