### PR TITLE
Add deleted migration back

### DIFF
--- a/db/migrate/20210423104935_add_goals_to_companies.rb
+++ b/db/migrate/20210423104935_add_goals_to_companies.rb
@@ -8,7 +8,6 @@ class AddGoalsToCompanies < ActiveRecord::Migration[6.1]
         t.column(:feedback, :boolean)
         t.column(:business_type, :string)
         t.column(:marketing_attitude, :string)
-        t.column(:budget, :bigint)
       end
     end
   end

--- a/db/migrate/20210430105032_add_budget_to_company.rb
+++ b/db/migrate/20210430105032_add_budget_to_company.rb
@@ -1,0 +1,7 @@
+# frozen_string_literal: true
+
+class AddBudgetToCompany < ActiveRecord::Migration[6.1]
+  def change
+    add_column :companies, :budget, :bigint
+  end
+end


### PR DESCRIPTION
Fixing `PG::DuplicateColumn: ERROR:  column "budget" of relation "companies" already exists`

It happened because `db/migrate/20210430105032_add_budget_to_company.rb` was deleted (by accident?) in #1101.