### PR TITLE
Sync specialist before geocoding to avoid duplicate creation in airtable

### DIFF
--- a/app/graphql/mutations/create_freelancer_account.rb
+++ b/app/graphql/mutations/create_freelancer_account.rb
@@ -62,8 +62,8 @@ module Mutations
       end
 
       if success
-        GeocodeAccountJob.perform_later(account, context[:client_ip])
         specialist.sync_to_airtable
+        GeocodeAccountJob.perform_later(account, context[:client_ip])
         create_application_record(specialist, args[:pid])
         specialist.send_confirmation_email
       end


### PR DESCRIPTION
Resolves: [PAIPAS#recH6KSOI1onDIYov](https://airtable.com/tblzKtqH2SVFDMJBw/viwV0Rl9slVuA8u2w/recH6KSOI1onDIYov?blocks=hide)

### Description

When creating a new specialist record it doesn't have an airtable ID yet. So if geocode "perform_later" happens before "sync_to_airtable" that one will also have no airtable id. And then both will sync with airtable without airtable id hence creating 2 records in airtable.

### Reviewer Checklist

- [ ] PR has a clear title and description
- [ ] Manually tested the changes that the PR introduces
- [ ] Changes introduced by the PR are covered by tests of acceptable quality
- [ ] Checked the quality of [commit messages](http://chris.beams.io/posts/git-commit/)