### PR TITLE
Use a composite key for the combobox options list

### DIFF
--- a/donut/src/components/Combobox/Menu.js
+++ b/donut/src/components/Combobox/Menu.js
@@ -54,7 +54,10 @@ const ComboboxMenu = React.forwardRef(function ComboboxMenu(
 
       {!isLoading && !hasReachedMax
         ? options.map((option, index) => (
-            <AutocompleteOption key={option.value} {...propsForOption(index)}>
+            <AutocompleteOption
+              key={`${option.value}-${index}`}
+              {...propsForOption(index)}
+            >
               {option.label}
             </AutocompleteOption>
           ))


### PR DESCRIPTION
This was causing a bug when there happened to be duplicate options that would fill up the option list with that option each time it rendered.

https://user-images.githubusercontent.com/1512593/121337816-d54c2c00-c914-11eb-84a0-f1273841f4a4.mov


### Reviewer Checklist

- [ ] PR has a clear title and description
- [ ] Manually tested the changes that the PR introduces
- [ ] Changes introduced by the PR are covered by tests of acceptable quality
- [ ] Checked the quality of [commit messages](http://chris.beams.io/posts/git-commit/)