### PR TITLE
Add links type to CaseStudy and Importer

### DIFF
--- a/app/graphql/types/case_study/content_interface.rb
+++ b/app/graphql/types/case_study/content_interface.rb
@@ -7,7 +7,7 @@ module Types
       description "Type definition for CaseStudy::Content"
       field_class BaseField
 
-      orphan_types(ParagraphContent, HeadingContent, ImagesContent, ResultsContent)
+      orphan_types(ParagraphContent, HeadingContent, ImagesContent, LinksContent, ResultsContent)
 
       field :id, ID, null: false, method: :uid
       field :section, Section, null: false

--- a/app/graphql/types/case_study/links_content.rb
+++ b/app/graphql/types/case_study/links_content.rb
@@ -1,0 +1,16 @@
+# frozen_string_literal: true
+
+module Types
+  module CaseStudy
+    class LinksContent < Types::BaseType
+      graphql_name "Links"
+      description "Type definition for CaseStudy::LinksContent"
+      implements Types::CaseStudy::ContentInterface
+
+      field :links, String, null: true
+      def links
+        object.content["links"]
+      end
+    end
+  end
+end

--- a/app/lib/airtable/case_study.rb
+++ b/app/lib/airtable/case_study.rb
@@ -47,6 +47,7 @@ module Airtable
         attach_heading(background, fields["Background Title"])
         attach_paragraph(background, fields["Background Text"])
         attach_images(background, Array(fields["Background Images"]))
+        attach_links(background, Array(fields["Background Links"]))
 
         overview = article.sections.new(type: "overview", position: 1)
         attach_heading(overview, fields["Project Overview Title"])
@@ -54,6 +55,7 @@ module Airtable
           attach_heading(overview, fields["Step #{i} Title"], size: "h2")
           attach_paragraph(overview, fields["Step #{i} Details"])
           attach_images(overview, Array(fields["Step #{i} Images"]))
+          attach_links(overview, Array(fields["Step #{i} Links"]))
         end
 
         outcome = article.sections.new(type: "outcome", position: 2)
@@ -61,6 +63,7 @@ module Airtable
         attach_results(outcome, [fields["Key Result 1"], fields["Key Result 2"], fields["Key Result 3"]])
         attach_paragraph(outcome, fields["Outcome Text"])
         attach_images(outcome, Array(fields["Outcome Images"]))
+        attach_links(background, Array(fields["Outcome Links"]))
 
         article.title = fields["Title"]
         article.subtitle = fields["Subtitle"]
@@ -106,6 +109,14 @@ module Airtable
 
     def attach_results(section, results)
       section.contents.new(type: "CaseStudy::ResultsContent", content: {results: results}, position: content_position)
+      increment_content_position
+    end
+
+    def attach_links(section, field)
+      return if field.blank?
+
+      links = field.first.split("\n")
+      section.contents.new(type: "CaseStudy::LinksContent", content: {links: links}, position: content_position)
       increment_content_position
     end
 

--- a/app/models/case_study/links_content.rb
+++ b/app/models/case_study/links_content.rb
@@ -1,0 +1,39 @@
+# frozen_string_literal: true
+
+module CaseStudy
+  class LinksContent < Content
+    uid_prefix "csc"
+
+    private
+
+    # { type: "links", content: { links: ["link1", "link2",...] } }
+    def valid_content
+      return if content.keys.size == 1 && content["links"].present?
+
+      errors.add(:content, "does not follow the type's requirements")
+    end
+  end
+end
+
+# == Schema Information
+#
+# Table name: case_study_contents
+#
+#  id         :bigint           not null, primary key
+#  content    :jsonb
+#  position   :integer
+#  type       :string
+#  uid        :string           not null
+#  created_at :datetime         not null
+#  updated_at :datetime         not null
+#  section_id :bigint           not null
+#
+# Indexes
+#
+#  index_case_study_contents_on_section_id  (section_id)
+#  index_case_study_contents_on_uid         (uid)
+#
+# Foreign Keys
+#
+#  fk_rails_...  (section_id => case_study_sections.id)
+#

--- a/spec/factories/case_study/contents.rb
+++ b/spec/factories/case_study/contents.rb
@@ -22,6 +22,11 @@ FactoryBot.define do
     content { {results: %w[1 2 3]} }
   end
 
+  factory :case_study_links_content, parent: :case_study_content, class: "CaseStudy::LinksContent" do
+    type { "CaseStudy::LinksContent" }
+    content { {links: [Faker::TvShows::SiliconValley.url, Faker::TvShows::SiliconValley.url]} }
+  end
+
   factory :case_study_images_content, parent: :case_study_content, class: "CaseStudy::ImagesContent" do
     type { "CaseStudy::ImagesContent" }
     content { {} }

--- a/spec/models/case_study/links_content_spec.rb
+++ b/spec/models/case_study/links_content_spec.rb
@@ -1,0 +1,11 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe CaseStudy::LinksContent, type: :model do
+  let(:paragraph) { build(:case_study_links_content) }
+
+  it "has a valid factory" do
+    expect(paragraph).to be_valid
+  end
+end


### PR DESCRIPTION
Resolves: [Importing Links](https://www.notion.so/Importing-Links-c389aa94ad874c8a8b271e3da9a9d627)

### Description

Adds a new content type, new graphql type, and adds links to importer.

### Reviewer Checklist

- [x] PR has a clear title and description
- [ ] Manually tested the changes that the PR introduces
- [x] Changes introduced by the PR are covered by tests of acceptable quality
- [x] Checked the quality of [commit messages](http://chris.beams.io/posts/git-commit/)
