### PR TITLE
Add queries for case study skills

### DIFF
--- a/app/graphql/types/query_type.rb
+++ b/app/graphql/types/query_type.rb
@@ -373,20 +373,23 @@ module Types
       current_user.searches
     end
 
-    field :case_study_skills, [Types::Skill], null: true
+    field :case_study_skills, Types::Skill.connection_type, null: true
 
     def case_study_skills
       ::Skill.where(id: ::CaseStudy::Skill.select(:skill_id).distinct)
     end
 
     field :popular_case_study_skills, [Types::Skill], null: true do
-      argument :first, Integer, required: false
+      argument :limit, Integer, required: false
     end
 
-    def popular_case_study_skills(first = nil)
-      skills_by_usage = ::CaseStudy::Skill.select("skill_id, COUNT(skill_id) as usage").order("usage DESC").group("skill_id")
-      skills_by_usage = skills_by_usage.limit(first) if first.present?
-      ::Skill.where(id: skills_by_usage.map(&:skill_id))
+    def popular_case_study_skills(limit = 20)
+      skills_by_usage = ::CaseStudy::Skill.select("skill_id, COUNT(skill_id) as usage").
+        order("usage DESC").
+        group("skill_id").
+        limit(limit).
+        map(&:skill_id)
+      ::Skill.where(id: skills_by_usage)
     end
   end
 end


### PR DESCRIPTION
Resolves: [PAIPAS#recUtQRhQPbkfrZYF](https://airtable.com/tblzKtqH2SVFDMJBw/viwbjBqy6YW12N7Rn/recUtQRhQPbkfrZYF?blocks=hide)

- [x] caseStudySkills this should return all of the skills that we have case study articles for.
- [x] popularCaseStudySkills this should return a skill connection type of skills ordered by number of case study articles they are attached to. We can then query for the first 15 using a query like...

### Reviewer Checklist

- [ ] PR has a clear title and description
- [ ] Manually tested the changes that the PR introduces
- [ ] Changes introduced by the PR are covered by tests of acceptable quality
- [ ] Checked the quality of [commit messages](http://chris.beams.io/posts/git-commit/)