### PR TITLE
Create heading component

### DIFF
--- a/app/javascript/src/views/ActiveTalent/Manage.js
+++ b/app/javascript/src/views/ActiveTalent/Manage.js
@@ -1,6 +1,6 @@
 import React from "react";
 import filter from "lodash/filter";
-import { Text, Tabs } from "@advisable/donut";
+import { Heading, Tabs } from "@advisable/donut";
 import TalentCard from "./TalentCard";
 import { Cards } from "./styles";
 import Empty from "./Empty";
@@ -12,16 +12,7 @@ export default ({ onClick, applications }) => {
 
   return (
     <>
-      <Text
-        mb={5}
-        as="h2"
-        fontSize="4xl"
-        color="neutral900"
-        fontWeight="medium"
-        letterSpacing="-0.04rem"
-      >
-        Manage Talent
-      </Text>
+      <Heading mb={6}>Manage Talent</Heading>
       <Tabs label="Tasks">
         <Tabs.Tab title="Active Talent">
           <Cards>

--- a/app/javascript/src/views/FreelancerProjects/ActiveApplications.js
+++ b/app/javascript/src/views/FreelancerProjects/ActiveApplications.js
@@ -1,6 +1,6 @@
 import React from "react";
 import filter from "lodash/filter";
-import { Text, Tabs } from "@advisable/donut";
+import { Heading, Tabs } from "@advisable/donut";
 import ActiveProject from "./ActiveProject";
 import { Cards } from "./styles";
 import Empty from "./Empty";
@@ -12,16 +12,7 @@ export default ({ onClick, applications }) => {
 
   return (
     <>
-      <Text
-        mb="l"
-        as="h2"
-        fontSize="28px"
-        color="neutral900"
-        fontWeight="medium"
-        letterSpacing="-0.04rem"
-      >
-        Active Projects
-      </Text>
+      <Heading marginBottom={6}>Active Projects</Heading>
       <Tabs label="Clients">
         <Tabs.Tab title="Active Clients">
           <Cards>

--- a/app/javascript/src/views/Projects/index.js
+++ b/app/javascript/src/views/Projects/index.js
@@ -2,7 +2,7 @@
 import React from "react";
 import { useLocation } from "react-router-dom";
 import { useQuery } from "@apollo/client";
-import { Container, Text } from "@advisable/donut";
+import { Container, Heading } from "@advisable/donut";
 import Loading from "./Loading";
 import { GET_PROJECTS } from "./queries";
 import ProjectsList from "./ProjectsList";
@@ -51,16 +51,7 @@ const Projects = () => {
 
       {viewer.isAccepted ? (
         <>
-          <Text
-            mb={5}
-            as="h2"
-            fontSize="4xl"
-            color="neutral900"
-            fontWeight="medium"
-            letterSpacing="-0.04rem"
-          >
-            Your Projects
-          </Text>
+          <Heading mb={6}>Your Projects</Heading>
 
           {loading ? (
             <Loading />

--- a/donut/src/components/Heading/Heading.stories.js
+++ b/donut/src/components/Heading/Heading.stories.js
@@ -1,0 +1,14 @@
+import React from "react";
+import { withKnobs } from "@storybook/addon-knobs";
+import Heading from "./";
+
+export default {
+  title: "Content/Heading",
+  decorators: [withKnobs],
+};
+
+export function Basic() {
+  return (
+    <Heading>Get Instant Access to World-Class Marketing Freelancers</Heading>
+  );
+}

--- a/donut/src/components/Heading/index.js
+++ b/donut/src/components/Heading/index.js
@@ -1,0 +1,10 @@
+import React from "react";
+import { StyledHeading } from "./styles";
+
+export default function Heading({
+  size = "4xl",
+  color = "neutral900",
+  ...props
+}) {
+  return <StyledHeading $size={size} color={color} {...props} />;
+}

--- a/donut/src/components/Heading/styles.js
+++ b/donut/src/components/Heading/styles.js
@@ -1,0 +1,52 @@
+import styled from "styled-components";
+import { variant, display, space, color, typography } from "styled-system";
+
+const headingSize = variant({
+  prop: "$size",
+  variants: {
+    "5xl": {
+      fontSize: "5xl",
+      fontWeight: 700,
+      lineHeight: "32px",
+      letterSpacing: "-0.04rem",
+    },
+    "4xl": {
+      fontSize: "4xl",
+      fontWeight: 600,
+      lineHeight: "28px",
+      letterSpacing: "-0.04rem",
+    },
+    "3xl": {
+      fontSize: "3xl",
+      fontWeight: 600,
+      lineHeight: "24px",
+      letterSpacing: "-0.03rem",
+    },
+    "2xl": {
+      fontSize: "2xl",
+      fontWeight: 650,
+      lineHeight: "24px",
+      letterSpacing: "-0.02rem",
+    },
+    xl: {
+      fontSize: "xl",
+      fontWeight: 650,
+      lineHeight: "20px",
+      letterSpacing: "-0.02rem",
+    },
+    lg: {
+      fontSize: "lg",
+      fontWeight: 650,
+      lineHeight: "20px",
+      letterSpacing: "-0.02rem",
+    },
+  },
+});
+
+export const StyledHeading = styled.h2(
+  headingSize,
+  space,
+  color,
+  display,
+  typography,
+);

--- a/donut/src/index.js
+++ b/donut/src/index.js
@@ -89,3 +89,6 @@ export * from "./components/VerticalLayout/styles";
 export { default as Notice } from "./components/Notice";
 
 export { default as Toggle } from "./components/Toggle";
+
+export { default as Heading } from "./components/Heading";
+export * from "./components/Heading/styles";


### PR DESCRIPTION
I've noticed that the majority of our headers we are repeating the same props to over and over again. I think it is important that our headers are consistent and so I think it's worth introducing a `Heading` component to ensure this rather than repeating the same props to the Text component each time. I have also opted for a slightly more bold default header as I think we should start doing this more to improve page hierarchy but this can be overwritten with the `fontWeight` prop anyway.

I have only applied it in a few places in order to keep the PR light.

### Reviewer Checklist

- [ ] PR has a clear title and description
- [ ] Manually tested the changes that the PR introduces
- [ ] Changes introduced by the PR are covered by tests of acceptable quality
- [ ] Checked the quality of [commit messages](http://chris.beams.io/posts/git-commit/)