### PR TITLE
Add Zappier action for sending finance emails

### DIFF
--- a/app/controllers/zappier_interactor_controller.rb
+++ b/app/controllers/zappier_interactor_controller.rb
@@ -162,6 +162,11 @@ class ZappierInteractorController < ApplicationController
     end
   end
 
+  def send_finance_email
+    GenerateFinanceCsvJob.perform_later(params[:email])
+    render json: {status: "OK."}
+  end
+
   private
 
   def find_and_update(model, attrs = {})

--- a/app/mailers/staff_mailer.rb
+++ b/app/mailers/staff_mailer.rb
@@ -23,6 +23,11 @@ class StaffMailer < ApplicationMailer
     mail(to: @sales_person.email_with_name, subject: "#{@user.account.name} reported #{@specialist.account.name} as problematic on #{@project.name}")
   end
 
+  def finance_csv(email, csv)
+    attachments["payouts.csv"] = {mime_type: "text/csv", content: csv}
+    mail(to: email, subject: "Payouts CSV", body: "Please find attached the CSV of payouts.")
+  end
+
   private
 
   def instance_variables_for_unresponsiveness_report(report)

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,24 +1,24 @@
 # frozen_string_literal: true
 
-require 'sidekiq/web'
-require 'admin_constraint'
+require "sidekiq/web"
+require "admin_constraint"
 
 Rails.application.routes.draw do
   match "(*any)", to: redirect { |_, req| "https://app.advisable.com#{req.fullpath}" }, via: :all, constraints: {host: "advisable.herokuapp.com"}
 
   if Rails.env.development? || ENV["STAGING"]
-    mount GraphqlPlayground::Rails::Engine, as: "graphql_playground", at: '/playground', graphql_path: '/graphql'
-    mount GraphqlPlayground::Rails::Engine, as: "toby_playground", at: '/toby_playground', graphql_path: '/toby_graphql'
+    mount GraphqlPlayground::Rails::Engine, as: "graphql_playground", at: "/playground", graphql_path: "/graphql"
+    mount GraphqlPlayground::Rails::Engine, as: "toby_playground", at: "/toby_playground", graphql_path: "/toby_graphql"
   end
 
   if ENV["TOBY"]
-    post '/toby_graphql', to: 'graphql#toby'
+    post "/toby_graphql", to: "graphql#toby"
     get "/toby", to: "application#toby"
     get "/toby/*toby", to: "application#toby"
   end
 
   namespace :admin do
-    mount Sidekiq::Web => '/sidekiq', constraints: AdminConstraint.new
+    mount Sidekiq::Web => "/sidekiq", constraints: AdminConstraint.new
     mount PgHero::Engine, at: "pghero", constraints: AdminConstraint.new
 
     resources :applications
@@ -42,7 +42,7 @@ Rails.application.routes.draw do
       resources :posts, as: :case_study
       resources :posts, as: :advice_required
       resources :posts do
-        post 'boost_post', on: :member
+        post "boost_post", on: :member
       end
     end
     namespace :case_study do
@@ -57,53 +57,54 @@ Rails.application.routes.draw do
     resources :labels
     resources :post_prompts
 
-    post 'resync', to: 'application#resync', as: :resync if ENV['STAGING']
-    get 'login/:gid', to: 'application#login_as', as: :login_as
+    post "resync", to: "application#resync", as: :resync if ENV["STAGING"]
+    get "login/:gid", to: "application#login_as", as: :login_as
 
-    post 'reset_test', to: 'application#reset_test', as: :reset_test if ENV['STAGING'] || Rails.env.development?
+    post "reset_test", to: "application#reset_test", as: :reset_test if ENV["STAGING"] || Rails.env.development?
 
-    root to: 'applications#index'
+    root to: "applications#index"
   end
 
-  post '/graphql', to: 'graphql#execute'
+  post "/graphql", to: "graphql#execute"
 
-  post '/stripe_events', to: 'stripe_events#create'
+  post "/stripe_events", to: "stripe_events#create"
 
-  get '/auth/:provider/callback', to: 'auth_providers#create'
-  get '/auth/failure', to: 'auth_providers#failure'
+  get "/auth/:provider/callback", to: "auth_providers#create"
+  get "/auth/failure", to: "auth_providers#failure"
 
-  get '/guild', to: 'application#guild', as: :guild_root
-  get '/guild/posts/:id', to: 'application#guild_post', as: :guild_post
-  get '/guild/*guild_path', to: 'application#guild'
+  get "/guild", to: "application#guild", as: :guild_root
+  get "/guild/posts/:id", to: "application#guild_post", as: :guild_post
+  get "/guild/*guild_path", to: "application#guild"
 
-  post '/webhooks/twilio_chat', to: 'webhooks#twilio_chat'
+  post "/webhooks/twilio_chat", to: "webhooks#twilio_chat"
 
   # Routes for internal tooling
-  get '/internal', to: 'application#internal', as: :internal_root
-  get '/internal/*guild_path', to: 'application#internal'
-  post '/projects/send_invites'
-  post '/projects/create_linkedin_ad'
+  get "/internal", to: "application#internal", as: :internal_root
+  get "/internal/*guild_path", to: "application#internal"
+  post "/projects/send_invites"
+  post "/projects/create_linkedin_ad"
 
-  get 'accounts/me'
-  post 'accounts/user'
-  post 'accounts/specialist'
+  get "accounts/me"
+  post "accounts/user"
+  post "accounts/specialist"
 
-  post 'zappier_interactor/create_application'
-  post 'zappier_interactor/update_application'
-  post 'zappier_interactor/update_interview'
-  post 'zappier_interactor/update_consultation'
-  post 'zappier_interactor/update_user'
-  post 'zappier_interactor/update_specialist'
-  post 'zappier_interactor/update_project'
-  post 'zappier_interactor/attach_previous_project_image'
-  post 'zappier_interactor/create_magic_link'
-  post 'zappier_interactor/enable_guild'
-  post 'zappier_interactor/boost_guild_post'
-  post 'zappier_interactor/import_case_study'
-  post 'zappier_interactor/post_case_study_to_guild'
-  post 'zappier_interactor/send_email'
+  post "zappier_interactor/create_application"
+  post "zappier_interactor/update_application"
+  post "zappier_interactor/update_interview"
+  post "zappier_interactor/update_consultation"
+  post "zappier_interactor/update_user"
+  post "zappier_interactor/update_specialist"
+  post "zappier_interactor/update_project"
+  post "zappier_interactor/attach_previous_project_image"
+  post "zappier_interactor/create_magic_link"
+  post "zappier_interactor/enable_guild"
+  post "zappier_interactor/boost_guild_post"
+  post "zappier_interactor/import_case_study"
+  post "zappier_interactor/post_case_study_to_guild"
+  post "zappier_interactor/send_email"
+  post "zappier_interactor/send_finance_email"
 
   # match every other route to the frontend codebase
-  root 'application#frontend'
-  get '*path', to: 'application#frontend', constraints: ->(req) { req.path.exclude?('rails/') }
+  root "application#frontend"
+  get "*path", to: "application#frontend", constraints: ->(req) { req.path.exclude?("rails/") }
 end

--- a/spec/controllers/zappier_interactor_controller_spec.rb
+++ b/spec/controllers/zappier_interactor_controller_spec.rb
@@ -803,4 +803,23 @@ RSpec.describe ZappierInteractorController, type: :request do
       end
     end
   end
+
+  describe "POST /send_finance_email" do
+    let(:params) { {email: "test@test.com", key: key} }
+
+    context "when no key" do
+      let(:key) { "" }
+
+      it "is unauthorized" do
+        post("/zappier_interactor/send_finance_email", params: params)
+        expect(response).to have_http_status(:unauthorized)
+      end
+    end
+
+    it "generates the csv" do
+      post("/zappier_interactor/send_finance_email", params: params)
+      expect(response).to have_http_status(:success)
+      expect(GenerateFinanceCsvJob).to have_been_enqueued.with("test@test.com")
+    end
+  end
 end


### PR DESCRIPTION
### Description

Adds Zappier action. Tested manually, works flawlessly with letter_opener if you have `sidekiq` running.

### Reviewer Checklist

- [x] PR has a clear title and description
- [x] Manually tested the changes that the PR introduces
- [x] Changes introduced by the PR are covered by tests of acceptable quality
- [x] Checked the quality of [commit messages](http://chris.beams.io/posts/git-commit/)