### PR TITLE
Stop querying specialist.image field

### DIFF
--- a/app/javascript/src/graphql/fragments/specialists.js
+++ b/app/javascript/src/graphql/fragments/specialists.js
@@ -7,9 +7,7 @@ export const specialistFields = gql`
     firstName
     lastName
     city
-    image {
-      url
-    }
+    avatar
     country {
       id
       name

--- a/app/javascript/src/graphql/fragments/viewerFields.graphql
+++ b/app/javascript/src/graphql/fragments/viewerFields.graphql
@@ -41,8 +41,5 @@ fragment ViewerFields on ViewerUnion {
     avatar
     guild
     guildCalendlyLink
-    image {
-      url
-    }
   }
 }

--- a/app/javascript/src/utilities/createTalkSession.js
+++ b/app/javascript/src/utilities/createTalkSession.js
@@ -1,11 +1,11 @@
 import Talk from "talkjs";
 
-const createTalkSession = viewer => {
+const createTalkSession = (viewer) => {
   const user = new Talk.User({
     id: viewer.id,
     name: viewer.name,
     email: viewer.email,
-    photoUrl: viewer.image?.url,
+    photoUrl: viewer.avatar,
     role: viewer.__typename === "Specialist" ? "Specialist" : "Client",
   });
 

--- a/app/javascript/src/views/ActiveTalent/TalentCard/index.js
+++ b/app/javascript/src/views/ActiveTalent/TalentCard/index.js
@@ -15,7 +15,7 @@ const TalentCard = ({ onClick, application }) => {
           mx="auto"
           display="inline-block"
           name={application.specialist.name}
-          url={application.specialist.image?.url}
+          url={application.specialist.avatar}
         />
         <Text
           fontSize="l"

--- a/app/javascript/src/views/ActiveTalent/fetchData.js
+++ b/app/javascript/src/views/ActiveTalent/fetchData.js
@@ -21,9 +21,7 @@ export default gql`
           specialist {
             id
             name
-            image {
-              url
-            }
+            avatar
           }
         }
       }

--- a/app/javascript/src/views/Booking/Sidebar.js
+++ b/app/javascript/src/views/Booking/Sidebar.js
@@ -39,11 +39,7 @@ const Sidebar = ({ data, history, tutorialModal }) => {
       <Sticky offset={98} enabled={!isMobile}>
         <motion.div initial={{ opacity: 0 }} animate={{ opacity: 1 }}>
           <Box paddingBottom="l">
-            <Avatar
-              size="l"
-              name={specialist.name}
-              url={specialist?.image?.url}
-            />
+            <Avatar size="l" name={specialist.name} url={specialist?.avatar} />
           </Box>
           <Text
             fontSize="xl"

--- a/app/javascript/src/views/Messages/Sidebar/ClientSidebar.js
+++ b/app/javascript/src/views/Messages/Sidebar/ClientSidebar.js
@@ -60,7 +60,7 @@ const ClientSidebar = (props) => {
   return (
     <>
       <Box paddingBottom="m">
-        <Avatar size="l" name={specialist.name} url={specialist?.image?.url} />
+        <Avatar size="l" name={specialist.name} url={specialist?.avatar} />
       </Box>
       <Box paddingBottom="xxs">
         <Text size="l" weight="semibold" color="neutral900">

--- a/app/javascript/src/views/Messages/getApplicationForClient.js
+++ b/app/javascript/src/views/Messages/getApplicationForClient.js
@@ -16,14 +16,12 @@ export default gql`
         id
         name
         city
+        avatar
         firstName
         linkedin
         country {
           id
           name
-        }
-        image {
-          url
         }
       }
     }


### PR DESCRIPTION
We have deprecated the image field in favour of the avatar field. This updates any queries that were calling the image field to use the avatar field. 

[Sentry Error](https://sentry.io/organizations/advisable/issues/2520038618/?project=2021209&query=is%3Aunresolved&statsPeriod=14d)

### Reviewer Checklist

- [x] PR has a clear title and description
- [ ] Manually tested the changes that the PR introduces
- [ ] Changes introduced by the PR are covered by tests of acceptable quality
- [x] Checked the quality of [commit messages](http://chris.beams.io/posts/git-commit/)