### PR TITLE
Add theme-color meta tag to header color

### DIFF
--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -18,6 +18,7 @@
 
     <link rel="icon" href="/favicon-32.png" sizes="32x32" />
     <link rel="icon" href="/favicon-192.png" sizes="192x192" />
+    <meta name="theme-color" content="#113ACB" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0, user-scalable=no" />
     <script src="https://cdn.polyfill.io/v2/polyfill.min.js"></script>
     <link


### PR DESCRIPTION
Set's the theme-colour meta tag to improve styling with new safari and mobile browsers.

![Screenshot 2021-07-19 at 11 05 54](https://user-images.githubusercontent.com/1512593/126143844-cbd03f40-8b7c-4ccc-b871-ca6d309dd76e.png)

### Reviewer Checklist

- [ ] PR has a clear title and description
- [ ] Manually tested the changes that the PR introduces
- [ ] Changes introduced by the PR are covered by tests of acceptable quality
- [ ] Checked the quality of [commit messages](http://chris.beams.io/posts/git-commit/)