### PR TITLE
Add db models for Messaging

### DIFF
--- a/app/models/account.rb
+++ b/app/models/account.rb
@@ -19,6 +19,9 @@ class Account < ApplicationRecord
   has_many :actor_notifications, class_name: "Notification", foreign_key: :actor_id, dependent: :destroy, inverse_of: :actor
   has_many :interviewer_articles, inverse_of: :interviewer, foreign_key: :interviewer_id, class_name: "CaseStudy::Article", dependent: :nullify
   has_many :editor_articles, inverse_of: :editor, foreign_key: :editor_id, class_name: "CaseStudy::Article", dependent: :nullify
+  has_many :messages, dependent: :destroy, foreign_key: :author_id, inverse_of: :author
+  has_many :conversation_participants, dependent: :destroy
+  has_many :conversations, through: :conversation_participants
 
   scope :active, -> { where(deleted_at: nil) }
 

--- a/app/models/conversation.rb
+++ b/app/models/conversation.rb
@@ -1,0 +1,23 @@
+# frozen_string_literal: true
+
+class Conversation < ApplicationRecord
+  include Uid
+  uid_prefix "cnv"
+
+  has_many :messages, dependent: :destroy
+  has_many :participants, class_name: "ConversationParticipant", dependent: :destroy
+end
+
+# == Schema Information
+#
+# Table name: conversations
+#
+#  id         :bigint           not null, primary key
+#  uid        :string           not null
+#  created_at :datetime         not null
+#  updated_at :datetime         not null
+#
+# Indexes
+#
+#  index_conversations_on_uid  (uid) UNIQUE
+#

--- a/app/models/conversation_participant.rb
+++ b/app/models/conversation_participant.rb
@@ -1,0 +1,28 @@
+# frozen_string_literal: true
+
+class ConversationParticipant < ApplicationRecord
+  belongs_to :account
+  belongs_to :conversation
+end
+
+# == Schema Information
+#
+# Table name: conversation_participants
+#
+#  id              :bigint           not null, primary key
+#  last_read_at    :datetime
+#  created_at      :datetime         not null
+#  updated_at      :datetime         not null
+#  account_id      :bigint           not null
+#  conversation_id :bigint           not null
+#
+# Indexes
+#
+#  index_conversation_participants_on_account_id       (account_id)
+#  index_conversation_participants_on_conversation_id  (conversation_id)
+#
+# Foreign Keys
+#
+#  fk_rails_...  (account_id => accounts.id)
+#  fk_rails_...  (conversation_id => conversations.id)
+#

--- a/app/models/message.rb
+++ b/app/models/message.rb
@@ -1,0 +1,33 @@
+# frozen_string_literal: true
+
+class Message < ApplicationRecord
+  include Uid
+  uid_prefix "msg"
+
+  belongs_to :author, class_name: "Account"
+  belongs_to :conversation
+end
+
+# == Schema Information
+#
+# Table name: messages
+#
+#  id              :bigint           not null, primary key
+#  content         :text
+#  uid             :string           not null
+#  created_at      :datetime         not null
+#  updated_at      :datetime         not null
+#  author_id       :bigint           not null
+#  conversation_id :bigint           not null
+#
+# Indexes
+#
+#  index_messages_on_author_id        (author_id)
+#  index_messages_on_conversation_id  (conversation_id)
+#  index_messages_on_uid              (uid) UNIQUE
+#
+# Foreign Keys
+#
+#  fk_rails_...  (author_id => accounts.id)
+#  fk_rails_...  (conversation_id => conversations.id)
+#

--- a/db/migrate/20210720082602_create_conversations.rb
+++ b/db/migrate/20210720082602_create_conversations.rb
@@ -1,0 +1,12 @@
+# frozen_string_literal: true
+
+class CreateConversations < ActiveRecord::Migration[6.1]
+  def change
+    create_table :conversations do |t|
+      t.string :uid, null: false
+
+      t.timestamps
+      t.index :uid, unique: true
+    end
+  end
+end

--- a/db/migrate/20210720082755_create_messages.rb
+++ b/db/migrate/20210720082755_create_messages.rb
@@ -1,0 +1,15 @@
+# frozen_string_literal: true
+
+class CreateMessages < ActiveRecord::Migration[6.1]
+  def change
+    create_table :messages do |t|
+      t.string :uid, null: false
+      t.text :content
+      t.references :author, null: false, foreign_key: {to_table: :accounts}
+      t.references :conversation, null: false, foreign_key: true
+
+      t.timestamps
+      t.index :uid, unique: true
+    end
+  end
+end

--- a/db/migrate/20210720083726_create_conversation_participants.rb
+++ b/db/migrate/20210720083726_create_conversation_participants.rb
@@ -1,0 +1,13 @@
+# frozen_string_literal: true
+
+class CreateConversationParticipants < ActiveRecord::Migration[6.1]
+  def change
+    create_table :conversation_participants do |t|
+      t.references :account, null: false, foreign_key: true
+      t.references :conversation, null: false, foreign_key: true
+      t.datetime :last_read_at
+
+      t.timestamps
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -409,6 +409,23 @@ ActiveRecord::Schema.define(version: 2021_07_20_085655) do
     t.index ["user_id"], name: "index_consultations_on_user_id"
   end
 
+  create_table "conversation_participants", force: :cascade do |t|
+    t.bigint "account_id", null: false
+    t.bigint "conversation_id", null: false
+    t.datetime "last_read_at"
+    t.datetime "created_at", precision: 6, null: false
+    t.datetime "updated_at", precision: 6, null: false
+    t.index ["account_id"], name: "index_conversation_participants_on_account_id"
+    t.index ["conversation_id"], name: "index_conversation_participants_on_conversation_id"
+  end
+
+  create_table "conversations", force: :cascade do |t|
+    t.string "uid", null: false
+    t.datetime "created_at", precision: 6, null: false
+    t.datetime "updated_at", precision: 6, null: false
+    t.index ["uid"], name: "index_conversations_on_uid", unique: true
+  end
+
   create_table "countries", force: :cascade do |t|
     t.string "name"
     t.string "currency"
@@ -605,6 +622,18 @@ ActiveRecord::Schema.define(version: 2021_07_20_085655) do
     t.string "status"
     t.index ["project_id"], name: "index_matches_on_project_id"
     t.index ["specialist_id"], name: "index_matches_on_specialist_id"
+  end
+
+  create_table "messages", force: :cascade do |t|
+    t.string "uid", null: false
+    t.text "content"
+    t.bigint "author_id", null: false
+    t.bigint "conversation_id", null: false
+    t.datetime "created_at", precision: 6, null: false
+    t.datetime "updated_at", precision: 6, null: false
+    t.index ["author_id"], name: "index_messages_on_author_id"
+    t.index ["conversation_id"], name: "index_messages_on_conversation_id"
+    t.index ["uid"], name: "index_messages_on_uid", unique: true
   end
 
   create_table "notifications", id: :uuid, default: -> { "gen_random_uuid()" }, force: :cascade do |t|
@@ -1136,6 +1165,8 @@ ActiveRecord::Schema.define(version: 2021_07_20_085655) do
   add_foreign_key "consultations", "skills"
   add_foreign_key "consultations", "specialists"
   add_foreign_key "consultations", "users"
+  add_foreign_key "conversation_participants", "accounts"
+  add_foreign_key "conversation_participants", "conversations"
   add_foreign_key "event_attendees", "events"
   add_foreign_key "event_attendees", "specialists"
   add_foreign_key "events", "specialists", column: "host_id"
@@ -1156,6 +1187,8 @@ ActiveRecord::Schema.define(version: 2021_07_20_085655) do
   add_foreign_key "labels", "skills"
   add_foreign_key "matches", "projects"
   add_foreign_key "matches", "specialists"
+  add_foreign_key "messages", "accounts", column: "author_id"
+  add_foreign_key "messages", "conversations"
   add_foreign_key "notifications", "accounts"
   add_foreign_key "notifications", "accounts", column: "actor_id"
   add_foreign_key "off_platform_projects", "specialists"

--- a/spec/factories/conversation_participants.rb
+++ b/spec/factories/conversation_participants.rb
@@ -1,0 +1,9 @@
+# frozen_string_literal: true
+
+FactoryBot.define do
+  factory :conversation_participant do
+    account
+    conversation
+    last_read_at { "2021-07-20 10:37:26" }
+  end
+end

--- a/spec/factories/conversations.rb
+++ b/spec/factories/conversations.rb
@@ -1,0 +1,5 @@
+# frozen_string_literal: true
+
+FactoryBot.define do
+  factory :conversation
+end

--- a/spec/factories/messages.rb
+++ b/spec/factories/messages.rb
@@ -1,0 +1,9 @@
+# frozen_string_literal: true
+
+FactoryBot.define do
+  factory :message do
+    content { "This is a content of a Message." }
+    author { association :account }
+    conversation
+  end
+end

--- a/spec/models/conversation_participant_spec.rb
+++ b/spec/models/conversation_participant_spec.rb
@@ -1,0 +1,9 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe ConversationParticipant, type: :model do
+  it "has a valid factory" do
+    expect(build(:conversation_participant)).to be_valid
+  end
+end

--- a/spec/models/conversation_spec.rb
+++ b/spec/models/conversation_spec.rb
@@ -1,0 +1,9 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe Conversation, type: :model do
+  it "has a valid factory" do
+    expect(build(:conversation)).to be_valid
+  end
+end

--- a/spec/models/message_spec.rb
+++ b/spec/models/message_spec.rb
@@ -1,0 +1,9 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe Message, type: :model do
+  it "has a valid factory" do
+    expect(build(:message)).to be_valid
+  end
+end


### PR DESCRIPTION
Resolves: [Notion](https://www.notion.so/advisable/Messaging-45cc15bedaa149c89166d5bfaf37bdfc?d=04e3edac-04d0-42be-9207-b28c96c9a088#58b6c70fb904482c918b272d596cd91d)

### Description

Adds DB models for messaging. 

### Reviewer Checklist

- [x] PR has a clear title and description
- [ ] Manually tested the changes that the PR introduces
- [ ] Changes introduced by the PR are covered by tests of acceptable quality
- [x] Checked the quality of [commit messages](http://chris.beams.io/posts/git-commit/)