### PR TITLE
Remove parallel tests for now

### DIFF
--- a/.github/workflows/ruby-tests.yml
+++ b/.github/workflows/ruby-tests.yml
@@ -78,13 +78,13 @@ jobs:
         uses: bahmutov/npm-install@v1
 
       - name: Setup database
-        run: bin/rails parallel:create db:migrate parallel:prepare
+        run: bin/rails db:create db:migrate db:test:prepare
 
       - name: Compile assets
         run: bin/rails webpacker:compile
 
       - name: Unit Tests
-        run: bin/rails parallel:spec['spec\/(?!system)']
+        run: bin/rspec --exclude-pattern "spec/system/**"
 
       - name: System Tests
         run: bin/rspec --pattern "spec/system/**/*_spec.rb"


### PR DESCRIPTION
The parallel tests seem to be still running the system tests and I can't figure out why.

### Reviewer Checklist

- [ ] PR has a clear title and description
- [ ] Manually tested the changes that the PR introduces
- [ ] Changes introduced by the PR are covered by tests of acceptable quality
- [ ] Checked the quality of [commit messages](http://chris.beams.io/posts/git-commit/)