### PR TITLE
Remove inputColor variant

### DIFF
--- a/donut/src/components/Input/index.js
+++ b/donut/src/components/Input/index.js
@@ -10,7 +10,6 @@ import {
 const Input = React.forwardRef(function Input(
   {
     size,
-    inputColor,
     prefix,
     suffix,
     error,
@@ -58,7 +57,6 @@ const Input = React.forwardRef(function Input(
       marginRight={marginRight}
       marginBottom={marginBottom}
       marginLeft={marginLeft}
-      inputColor={inputColor}
     >
       {prefix ? (
         <StyledInputDecoration onClick={handleDecorationClick}>
@@ -84,7 +82,6 @@ Input.defaultProps = {
   onBlur: () => {},
   onFocus: () => {},
   size: "md",
-  inputColor: "gray",
 };
 
 export default Input;

--- a/donut/src/components/Input/styles.js
+++ b/donut/src/components/Input/styles.js
@@ -149,43 +149,22 @@ const size = variant({
   },
 });
 
-const inputColor = variant({
-  prop: "inputColor",
-  variants: {
-    white: {
-      background: "white",
-      boxShadow: `0 4px 8px -4px ${rgba(theme.colors.neutral900, 0.2)}`,
-
-      "&[data-focused='true']": {
-        background: "white",
-        borderColor: "blue900",
-      },
-
-      [`${StyledInputControl}::placeholder`]: {
-        color: "neutral500",
-      },
-    },
-    gray: {
-      background: "#eff0f3",
-
-      "&[data-focused='true']": {
-        background: "#eff0f3",
-        borderColor: "blue900",
-      },
-    },
-  },
-});
-
 export const StyledInput = styled.div`
   width: 100%;
   display: flex;
+  background: #eff0f3;
   box-sizing: border-box;
   border: 2px solid transparent;
   border-radius: ${BORDER_RADIUS}px;
+
+  &[data-focused="true"] {
+    background: #eff0f3;
+    border-color: ${theme.colors.blue900};
+  }
+
   ${(props) => props.$error && StyledInput_Error};
   ${(props) => props.$disabled && StyledInput_Disabled};
 
-  ${inputColor};
   ${size};
   ${margin};
 `;


### PR DESCRIPTION
This actually broke a lot of other input components like textareas and dropdowns as they also work off of the input styles for their base styling but we weren't passing the inputColor prop through. Now that we are using a white background in explorer though we don't even need it.

### Reviewer Checklist

- [ ] PR has a clear title and description
- [ ] Manually tested the changes that the PR introduces
- [ ] Changes introduced by the PR are covered by tests of acceptable quality
- [ ] Checked the quality of [commit messages](http://chris.beams.io/posts/git-commit/)