### PR TITLE
Fix FormField propTypes

### DIFF
--- a/app/javascript/src/components/FormField.js
+++ b/app/javascript/src/components/FormField.js
@@ -139,8 +139,8 @@ const FormField = ({
 
 FormField.propTypes = {
   label: PropTypes.string,
-  prefix: PropTypes.element,
-  suffix: PropTypes.element,
+  prefix: PropTypes.elementType,
+  suffix: PropTypes.elementType,
   description: PropTypes.string,
   widget: PropTypes.func,
 };


### PR DESCRIPTION
Updates `FormField` prop types to allow either a component or a string for `prefix` and `suffix` props.