### PR TITLE
Encode CSRF tokens in sentry error

### DIFF
--- a/app/controllers/graphql_controller.rb
+++ b/app/controllers/graphql_controller.rb
@@ -37,8 +37,8 @@ class GraphqlController < ApplicationController
       extra: {
         headers: headers,
         tokens: request_authenticity_tokens,
-        real: real_csrf_token(session),
-        global: global_csrf_token(session),
+        real: Base64.encode64(real_csrf_token(session)),
+        global: Base64.encode64(global_csrf_token(session)),
         session: cookies["_advisable_session"]
       }
     )


### PR DESCRIPTION
Sentry was raising the following error when trying to log the error...

```
sentry: Event sending failed: "\x96" from ASCII-8BIT to UTF-8
```

### Reviewer Checklist

- [ ] PR has a clear title and description
- [ ] Manually tested the changes that the PR introduces
- [ ] Changes introduced by the PR are covered by tests of acceptable quality
- [ ] Checked the quality of [commit messages](http://chris.beams.io/posts/git-commit/)