### PR TITLE
Support inline images in favicon finder

### DIFF
--- a/app/jobs/company_favicon_finder_job.rb
+++ b/app/jobs/company_favicon_finder_job.rb
@@ -1,55 +1,76 @@
 # frozen_string_literal: true
 
 class CompanyFaviconFinderJob < ApplicationJob
+  attr_reader :company, :company_website, :icons
+
   queue_as :default
 
   def perform(company, force: false)
     return if company.website.blank? || (company.favicon.present? && !force)
 
     @company = company
-    iconuri = shortcut_uri
+    @company_website = parse_company_website
+    @icons = icons_from_meta
+
+    if icons.any?
+      find_biggest_favicon
+    else
+      iconuri = company_website
+      iconuri.path = "/favicon.ico"
+      favicon_from_uri(iconuri)
+    end
+  end
+
+  def icons_from_meta
+    res = Faraday.new(url: company_website) { |f| f.use(FaradayMiddleware::FollowRedirects) }.get
+    doc = Nokogiri::HTML(res.body)
+    doc.xpath('//link[@rel="icon" or @rel="shortcut icon" or @rel="apple-touch-icon" or @rel="apple-touch-icon-precomposed"]')
+  end
+
+  def find_biggest_favicon
+    biggest = icons.max_by { |i| i.attributes["sizes"]&.value.to_i }
+    selected = biggest.presence || icons.first
+    if selected["href"].starts_with?("data:")
+      favicon_from_base64(selected["href"])
+    else
+      iconuri = URI.parse(selected["href"])
+      if iconuri.host.blank?
+        path = iconuri.path
+        iconuri = company_website
+        iconuri.path = path
+      end
+      favicon_from_uri(iconuri)
+    end
+  end
+
+  def favicon_from_uri(iconuri)
     filename = File.basename(iconuri.path)
     res = Faraday.new(url: iconuri) { |f| f.use(FaradayMiddleware::FollowRedirects) }.get
     return unless res.status == 200
 
+    attach_favicon(filename, res.body)
+  end
+
+  def favicon_from_base64(data)
+    m = %r{data:image/(\w+);base64,(.+)}.match(data)
+    attach_favicon("favicon.#{m[1]}", Base64.decode64(m[2]))
+  end
+
+  def attach_favicon(filename, data)
     tempfile = Tempfile.new(filename, binmode: true)
-    tempfile.write(res.body)
+    tempfile.write(data)
     tempfile.close
     company.favicon.attach(io: File.open(tempfile.path), filename: filename)
   end
 
-  private
-
-  def shortcut_uri
-    uri = company_website
-    res = Faraday.new(url: uri) { |f| f.use(FaradayMiddleware::FollowRedirects) }.get
-    doc = Nokogiri::HTML(res.body)
-    icons = doc.xpath('//link[@rel="icon" or @rel="shortcut icon" or @rel="apple-touch-icon" or @rel="apple-touch-icon-precomposed"]')
-
-    if icons.any?
-      biggest = icons.max_by { |i| i.attributes["sizes"]&.value.to_i }
-      selected = biggest.presence || icons.first
-      iconuri = URI.parse(selected["href"])
-      if iconuri.host.blank?
-        path = iconuri.path
-        iconuri = uri
-        iconuri.path = path
-      end
-    else
-      iconuri = uri
-      iconuri.path = "/favicon.ico"
-    end
-    iconuri
-  end
-
-  def company_website
-    uri = URI.parse(@company.website)
+  def parse_company_website
+    uri = URI.parse(company.website)
     case uri
     when URI::HTTP, URI::HTTPS
       uri.path = "/"
     when URI::Generic
       # https://rubular.com/r/jcPny2GqaBObpW
-      domain = @company.website.match(%r{(?<protocol>https?:)?(?<slashes>//)?(?<domain>\w*\.\w*)/?.*$})[:domain]
+      domain = company.website.match(%r{(?<protocol>https?:)?(?<slashes>//)?(?<domain>\w*\.\w*)/?.*$})[:domain]
       uri = URI.parse("http://#{domain}")
     else
       raise "unsupported url class (#{url.class}) for #{url}"


### PR DESCRIPTION
Resolves: https://sentry.io/organizations/advisable/issues/2503757517/?environment=production&project=2021209&query=is%3Aunresolved

### Description

Apparently some companies inline their favicons. Adding the support wasn't that difficult, but then the class was completely weird. So I ended up refactoring until it somewhat made sense again.

The gist of the change is in `favicon_from_base64`. Everything else is moving stuff around.

### Reviewer Checklist

- [ ] PR has a clear title and description
- [ ] Manually tested the changes that the PR introduces
- [ ] Changes introduced by the PR are covered by tests of acceptable quality
- [ ] Checked the quality of [commit messages](http://chris.beams.io/posts/git-commit/)