### PR TITLE
Keep trying to find a favicon if 404

### DIFF
--- a/app/jobs/company_favicon_finder_job.rb
+++ b/app/jobs/company_favicon_finder_job.rb
@@ -82,8 +82,8 @@ class CompanyFaviconFinderJob < ApplicationJob
     when URI::HTTP, URI::HTTPS
       uri.path = "/"
     when URI::Generic
-      # https://rubular.com/r/jcPny2GqaBObpW
-      domain = company.website.match(%r{(?<protocol>https?:)?(?<slashes>//)?(?<domain>\w*\.\w*)/?.*$})[:domain]
+      # https://rubular.com/r/Eu6qsxoakbGpsA
+      domain = company.website.match(%r{(?<protocol>https?:)?(?<slashes>//)?(?<www>www\.)?(?<domain>\w*\.\w*)/?.*$})[:domain]
       uri = URI.parse("http://#{domain}")
     else
       raise "unsupported url class (#{url.class}) for #{url}"


### PR DESCRIPTION
### Description

44 out of 64 companies that have a website have biggest favicons in source that 404 🤦‍♂️

Ran this on production and now all but 7 companies have favicons 🥳 

Did 2 follow-up improvements:
- handle when server responds with 200 but is actually an error html page
- improve regex domain when website has no http(s) but has www

This is now down to 3 companies without favicons, all of which actually are either malformed urls or do not have a favicon 🥳

### Reviewer Checklist

- [ ] PR has a clear title and description
- [ ] Manually tested the changes that the PR introduces
- [ ] Changes introduced by the PR are covered by tests of acceptable quality
- [ ] Checked the quality of [commit messages](http://chris.beams.io/posts/git-commit/)