### PR TITLE
Add deleted_at to Specialist

### DIFF
--- a/app/jobs/send_application_information_job.rb
+++ b/app/jobs/send_application_information_job.rb
@@ -13,10 +13,9 @@ class SendApplicationInformationJob < ApplicationJob
 
     specialists = Specialist.
       joins(:account).
-      active.
       available.
       not_rejected.
-      where(account: {deleted_at: nil}).
+      merge(Account.active).
       where(id: specialist_ids_by_skill).
       where.not(id: specialists_with_existing_applications)
 

--- a/app/lib/recommendation.rb
+++ b/app/lib/recommendation.rb
@@ -9,7 +9,7 @@ module Recommendation
 
   def self.recommend(specialist)
     recommender = RECOMMENDERS.sample
-    others = Specialist.active.accepted.guild.joins(:account).merge(Account.active).where.not(id: specialist.id)
+    others = Specialist.accepted.guild.joins(:account).merge(Account.active).where.not(id: specialist.id)
     recommender.for(specialist, others)
   end
 end

--- a/app/lib/toby/resources/account.rb
+++ b/app/lib/toby/resources/account.rb
@@ -14,6 +14,7 @@ module Toby
       attribute :permissions, Attributes::TextArray
       attribute :unsubscribed_from, Attributes::TextArray
       attribute :confirmed_at, Attributes::DateTime
+      attribute :deleted_at, Attributes::DateTime
       attribute :created_at, Attributes::DateTime, readonly: true
       attribute :updated_at, Attributes::DateTime, readonly: true
 

--- a/app/lib/toby/resources/specialist.rb
+++ b/app/lib/toby/resources/specialist.rb
@@ -17,7 +17,6 @@ module Toby
       attribute :skills, Attributes::HasManyThrough
       attribute :industries, Attributes::HasManyThrough
       attribute :unavailable_until, Attributes::Date
-      attribute :deleted_at, Attributes::DateTime
       attribute :created_at, Attributes::DateTime, readonly: true
       attribute :updated_at, Attributes::DateTime, readonly: true
 

--- a/app/models/account.rb
+++ b/app/models/account.rb
@@ -5,6 +5,7 @@ class Account < ApplicationRecord
   include Tutorials
   include Permissionable
   include Featurable
+  include SoftDeletable
 
   SUBSCRIPTIONS = ["All", "SMS Alerts", "Automated Invitations", "Personal Invitations", "Onboarding Emails", "Status Surveys"].freeze
 
@@ -22,8 +23,6 @@ class Account < ApplicationRecord
   has_many :messages, dependent: :destroy, foreign_key: :author_id, inverse_of: :author
   has_many :conversation_participants, dependent: :destroy
   has_many :conversations, through: :conversation_participants
-
-  scope :active, -> { where(deleted_at: nil) }
 
   has_secure_password validations: false
   validates :password, length: {minimum: 8}, allow_blank: true, confirmation: true

--- a/app/models/case_study/article.rb
+++ b/app/models/case_study/article.rb
@@ -2,7 +2,7 @@
 
 module CaseStudy
   class Article < ApplicationRecord
-    include SoftDeleteable
+    include SoftDeletable
     include Uid
     uid_prefix "csa"
 
@@ -24,7 +24,7 @@ module CaseStudy
 
     scope :published, -> { where.not(published_at: nil) }
     scope :by_score, -> { order('score DESC NULLS LAST') }
-    scope :available_specialists, -> { joins(:specialist).merge(Specialist.active.available) }
+    scope :available_specialists, -> { joins(:specialist).merge(Specialist.available).joins(specialist: :account).merge(Account.active) }
     scope :exclude_archived_for, ->(user) { where.not(id: user.archived_articles.select(:article_id)) }
   end
 end

--- a/app/models/concerns/soft_deletable.rb
+++ b/app/models/concerns/soft_deletable.rb
@@ -2,7 +2,7 @@
 
 # Adds soft delete functionality to ActiveRecord models.
 # You need to add `deleted_at` datetime column in the model via a migration.
-module SoftDeleteable
+module SoftDeletable
   extend ActiveSupport::Concern
 
   included do

--- a/app/models/specialist.rb
+++ b/app/models/specialist.rb
@@ -15,7 +15,6 @@ class Specialist < ApplicationRecord
   include SpecialistOrUser
   include Subscriber
   include Resizable
-  include SoftDeleteable
   include ::Airtable::Syncable
   include ::Guild::SpecialistsConcern
 
@@ -118,7 +117,6 @@ end
 #  community_invited_to_call_at      :datetime
 #  community_score                   :integer
 #  community_status                  :string
-#  deleted_at                        :datetime
 #  encrypted_phone_number            :string
 #  encrypted_phone_number_iv         :string
 #  guild                             :boolean          default(FALSE)

--- a/db/migrate/20210901093334_add_deleted_at_to_specialists.rb
+++ b/db/migrate/20210901093334_add_deleted_at_to_specialists.rb
@@ -1,7 +1,0 @@
-# frozen_string_literal: true
-
-class AddDeletedAtToSpecialists < ActiveRecord::Migration[6.1]
-  def change
-    add_column :specialists, :deleted_at, :datetime
-  end
-end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -987,7 +987,6 @@ ActiveRecord::Schema.define(version: 2021_09_01_093424) do
     t.string "trustpilot_review_status"
     t.string "campaign_medium"
     t.string "application_status"
-    t.datetime "deleted_at"
     t.index ["account_id"], name: "index_specialists_on_account_id"
     t.index ["airtable_id"], name: "index_specialists_on_airtable_id"
     t.index ["country_id"], name: "index_specialists_on_country_id"

--- a/spec/models/concerns/soft_deletable_spec.rb
+++ b/spec/models/concerns/soft_deletable_spec.rb
@@ -2,16 +2,16 @@
 
 require "rails_helper"
 
-class DummySoftDeleteable < ApplicationRecord
-  include SoftDeleteable
+class DummySoftDeletable < ApplicationRecord
+  include SoftDeletable
 end
 
-RSpec.describe SoftDeleteable do
+RSpec.describe SoftDeletable do
   let(:article) { create(:case_study_article) }
 
   it "generates the expected set of methods" do
-    expect(DummySoftDeleteable.instance_methods).to include(:soft_delete!, :restore!)
-    expect(DummySoftDeleteable.methods(false)).to include(:active, :deleted)
+    expect(DummySoftDeletable.instance_methods).to include(:soft_delete!, :restore!)
+    expect(DummySoftDeletable.methods(false)).to include(:active, :deleted)
   end
 
   describe "#soft_delete!" do


### PR DESCRIPTION
Resolves: [PAIPAS#recsWXAxwicPa5PNz](https://airtable.com/tblzKtqH2SVFDMJBw/viwbjBqy6YW12N7Rn/recsWXAxwicPa5PNz?blocks=hide)

### Description

- ~adds deleted_at to Specialist~
- cleans up referrer column
- add deleted_at to Toby for ~Specialist~ Account and Article
- exclude deleted Specialists from queries
- logout deleted ~Specialists~ Accounts

I think I got all the excludes where relevant but maybe not 😅

### Reviewer Checklist

- [x] PR has a clear title and description
- [ ] Manually tested the changes that the PR introduces
- [x] Changes introduced by the PR are covered by tests of acceptable quality
- [x] Checked the quality of [commit messages](http://chris.beams.io/posts/git-commit/)