### PR TITLE
Don't prefetch guild events query for header count

### DIFF
--- a/app/views/application/_guild.html.erb
+++ b/app/views/application/_guild.html.erb
@@ -1,4 +1,5 @@
 <div id='js-modal-root'></div>
+<div id="guildData" data-upcoming-events="<%= Event.upcoming.size %>">
 <%= stylesheet_pack_tag "guild" %>
 <%= javascript_packs_with_chunks_tag "guild" %>
 <%= render "noscript" %>

--- a/app/views/application/guild.html.erb
+++ b/app/views/application/guild.html.erb
@@ -1,2 +1,1 @@
-<div id="guildData" data-upcoming-events="<%= Event.upcoming.size %>">
 <%= render "guild" %>


### PR DESCRIPTION
Removes one of the large queries when loading guild by inlining the events count in the rails template.

### Reviewer Checklist

- [ ] PR has a clear title and description
- [ ] Manually tested the changes that the PR introduces
- [ ] Changes introduced by the PR are covered by tests of acceptable quality
- [ ] Checked the quality of [commit messages](http://chris.beams.io/posts/git-commit/)