### PR TITLE
Strip href of favicon because people are bastards

### DIFF
--- a/app/jobs/company_favicon_finder_job.rb
+++ b/app/jobs/company_favicon_finder_job.rb
@@ -36,6 +36,7 @@ class CompanyFaviconFinderJob < ApplicationJob
     if href.starts_with?("data:")
       favicon_from_base64(href)
     else
+      href = href.strip
       href = "http:#{href}" if href.starts_with?("//")
       href.gsub("../", "")
       iconuri = URI.parse(href)


### PR DESCRIPTION
Resolves: https://github.com/advisablecom/Advisable/issues/1385

### Description

`<link href=" https://www.testchecks.com/wp-content/uploads/2016/04/testflav.png" rel="icon">`

![selected](https://user-images.githubusercontent.com/986645/132459088-48af608d-fe35-4a08-a13a-ef09a6dca4f3.gif)

### Reviewer Checklist

- [ ] PR has a clear title and description
- [ ] Manually tested the changes that the PR introduces
- [ ] Changes introduced by the PR are covered by tests of acceptable quality
- [ ] Checked the quality of [commit messages](http://chris.beams.io/posts/git-commit/)