### PR TITLE
Handle blank links

### DIFF
--- a/app/lib/airtable/case_study.rb
+++ b/app/lib/airtable/case_study.rb
@@ -126,7 +126,9 @@ module Airtable
     def attach_links(section, field)
       return if field.blank?
 
-      links = field.first.split("\n")
+      links = field.first.split("\n").reject(&:blank?)
+      return if links.blank?
+
       section.contents.new(type: "CaseStudy::LinksContent", content: {links: links}, position: content_position)
       increment_content_position
     end


### PR DESCRIPTION
Resolves: https://github.com/advisablecom/Advisable/issues/1387

### Description

[This case study](https://airtable.com/tblSVg1UX0649n1vG/viw2krXL42p6cX32t/recroovBjmhS615U7?blocks=hide) has in `STEP 4 LINKS` this content:

```


```

which gets in our app as

```
[3] pry(#<Airtable::CaseStudy>)> field
=> ["\n"]
```

which creates `CaseStudy::LinksContent` with `content: {links: []}`.

Now we check what we get after splitting and additionally reject all the blank lines. Just in case.

### Reviewer Checklist

- [ ] PR has a clear title and description
- [ ] Manually tested the changes that the PR introduces
- [ ] Changes introduced by the PR are covered by tests of acceptable quality
- [ ] Checked the quality of [commit messages](http://chris.beams.io/posts/git-commit/)