### PR TITLE
Add contains filter to belongs to attribute types in Toby

### DIFF
--- a/app/lib/toby/lookups/accounts/email.rb
+++ b/app/lib/toby/lookups/accounts/email.rb
@@ -4,7 +4,7 @@ module Toby
   module Lookups
     module Accounts
       class Email < Attributes::String
-        filter :is, Filters::Equals do |records, value|
+        filter :is, Filters::Equals do |records, _attribute, value|
           records.includes(:account).
             where(accounts: {email: value[0]})
         end

--- a/app/lib/toby/lookups/projects/sales_person.rb
+++ b/app/lib/toby/lookups/projects/sales_person.rb
@@ -4,7 +4,7 @@ module Toby
   module Lookups
     module Projects
       class SalesPerson < Attributes::String
-        filter :is, Filters::Equals do |records, value|
+        filter :is, Filters::Equals do |records, _attribute, value|
           records.includes(user: {company: :sales_person}).
             where(sales_person: {username: value[0]})
         end

--- a/app/lib/toby/resolvers/collection.rb
+++ b/app/lib/toby/resolvers/collection.rb
@@ -26,7 +26,7 @@ module Toby
           next if filter_class.nil?
 
           @records = if filter_class.block.present?
-                       filter_class.block.call(@records, args[:value])
+                       filter_class.block.call(@records, attribute, args[:value])
                      else
                        filter_class.apply(@records, attribute, value: args[:value])
                      end


### PR DESCRIPTION
Resolves: https://github.com/advisablecom/Advisable/issues/1393

### Description

Looking at that error we have 2 issues:
1. belongs_to needs a way to know what the column name is
2. users expect to search by company name not id

This PR aims at addressing both by:
1. fixing one of to know how to work with belongs_to
2. introducing `contains…` on belongs_to that calls that resources `#search`

### Reviewer Checklist

- [ ] PR has a clear title and description
- [ ] Manually tested the changes that the PR introduces
- [ ] Changes introduced by the PR are covered by tests of acceptable quality
- [ ] Checked the quality of [commit messages](http://chris.beams.io/posts/git-commit/)