### PR TITLE
Update gems

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -60,7 +60,10 @@ gem "graphql_playground-rails"
 gem "email_reply_parser"
 gem "administrate-field-active_storage"
 
-gem "debug"
+gem "pry"
+gem "pry-rails"
+# gem "pry-doc" Does not support Ruby 3 yet
+gem "pry-byebug", github: "deivid-rodriguez/pry-byebug" # Uses pry 0.14
 gem "ruby-progressbar", require: false
 gem "app_profiler"
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,3 +1,11 @@
+GIT
+  remote: https://github.com/deivid-rodriguez/pry-byebug.git
+  revision: bf28c9781c434b2f00a83130ec5a8a992a691183
+  specs:
+    pry-byebug (3.9.0)
+      byebug (~> 11.0)
+      pry (>= 0.13, < 0.15)
+
 GEM
   remote: https://rubygems.org/
   specs:
@@ -115,6 +123,7 @@ GEM
       msgpack (~> 1.0)
     brakeman (5.1.1)
     builder (3.2.4)
+    byebug (11.1.3)
     capybara (3.35.3)
       addressable
       mini_mime (>= 0.1.3)
@@ -140,9 +149,6 @@ GEM
     database_cleaner-core (2.0.1)
     datetime_picker_rails (0.0.7)
       momentjs-rails (>= 2.8.1)
-    debug (1.0.0)
-      irb
-      reline (>= 0.2.7)
     diff-lcs (1.4.4)
     docile (1.4.0)
     dotenv (2.7.6)
@@ -224,9 +230,6 @@ GEM
     image_processing (1.12.1)
       mini_magick (>= 4.9.5, < 5)
       ruby-vips (>= 2.0.17, < 3)
-    io-console (0.5.9)
-    irb (1.3.7)
-      reline (>= 0.2.7)
     jmespath (1.4.0)
     jquery-rails (4.4.0)
       rails-dom-testing (>= 1, < 3)
@@ -325,6 +328,8 @@ GEM
     pry (0.14.1)
       coderay (~> 1.1)
       method_source (~> 1.0)
+    pry-rails (0.3.9)
+      pry (>= 0.10.4)
     public_suffix (4.0.6)
     puma (5.4.0)
       nio4r (~> 2.0)
@@ -376,8 +381,6 @@ GEM
       ffi (~> 1.0)
     redis (4.4.0)
     regexp_parser (2.1.1)
-    reline (0.2.7)
-      io-console (~> 0.5)
     rexml (3.2.5)
     rouge (3.26.0)
     rspec (3.10.0)
@@ -556,7 +559,6 @@ DEPENDENCIES
   countries
   dalli
   database_cleaner-active_record
-  debug
   dotenv-rails
   email_reply_parser
   factory_bot_rails
@@ -587,6 +589,9 @@ DEPENDENCIES
   pdfmonkey
   pg (>= 0.18, < 2.0)
   pghero
+  pry
+  pry-byebug!
+  pry-rails
   puma
   puma_worker_killer
   pundit


### PR DESCRIPTION
### Description

1. update gems
2. ~move from pry to [debug](https://github.com/ruby/debug)~

Reasons for 2:
- Ruby 3.1 will launch with `debug` baked in
- comes with a VS extension
- super fast and responsive
- pry seems to be stagnating and it and a lot of dependent gems still don't fully support ruby 3.x

I'll miss the nice pry syntax but we'll get used to [the new syntax](https://github.com/ruby/debug#debug-command-on-the-debug-console) I guess.

Update: `debug` doesn't work for us for unknown reason. Opened an issue: https://github.com/ruby/debug/issues/273

### Reviewer Checklist

- [ ] PR has a clear title and description
- [ ] Manually tested the changes that the PR introduces
- [ ] Changes introduced by the PR are covered by tests of acceptable quality
- [ ] Checked the quality of [commit messages](http://chris.beams.io/posts/git-commit/)