### PR TITLE
Field to check for conversation with an Account

### DIFF
--- a/app/graphql/types/account_interface.rb
+++ b/app/graphql/types/account_interface.rb
@@ -31,12 +31,9 @@ module Types
       account.features.keys
     end
 
-    field :conversation_with, Types::Conversation, null: true do
-      argument :id, ID, required: true
-    end
-    def conversation_with(id:)
-      account = Account.find_by_uid!(id)
-      Conversation.find_existing_with([current_user.account, account])
+    field :conversation, Types::Conversation, null: true
+    def conversation
+      Conversation.find_existing_with([current_user.account, object.account])
     end
   end
 end

--- a/app/models/account.rb
+++ b/app/models/account.rb
@@ -33,19 +33,6 @@ class Account < ApplicationRecord
   register_permissions :admin, :team_manager, :editor
   featurize :test, :case_studies
 
-  def self.find_by_uid!(uid)
-    case uid
-    when /^spe_/
-      Specialist.find_by!(uid: uid).account
-    when /^use_/
-      User.find_by!(uid: uid).account
-    when /^acc_/
-      find_by!(uid: uid)
-    else
-      raise ActiveRecord::RecordNotFound
-    end
-  end
-
   def specialist_or_user
     specialist || user
   end

--- a/spec/models/account_spec.rb
+++ b/spec/models/account_spec.rb
@@ -18,38 +18,6 @@ RSpec.describe Account, type: :model do
     expect(account).to be_valid
   end
 
-  describe "find_by_uid!" do
-    context "when specialist" do
-      let!(:specialist) { create(:specialist) }
-
-      it "returns the account" do
-        expect(described_class.find_by_uid!(specialist.uid)).to eq(specialist.account)
-      end
-    end
-
-    context "when user" do
-      let!(:user) { create(:user) }
-
-      it "returns the account" do
-        expect(described_class.find_by_uid!(user.uid)).to eq(user.account)
-      end
-    end
-
-    context "when account" do
-      let!(:account) { create(:account) }
-
-      it "returns the account" do
-        expect(described_class.find_by_uid!(account.uid)).to eq(account)
-      end
-    end
-
-    context "when other" do
-      it "raises a not_found error" do
-        expect { described_class.find_by_uid!("asd_1234") }.to raise_error(ActiveRecord::RecordNotFound)
-      end
-    end
-  end
-
   describe "#has_password?" do
     it "returns true when there is a password_digest" do
       inst = create(factory, password: "testing123")


### PR DESCRIPTION
Resolves: [Field to check for conversation with specialist](https://app.asana.com/0/1200887453920251/1201044278954312/f)

### Description

I expanded a bit to allow anything to be passed in - specialist, user, or an account. This should be most flexible for any scenario.

### Reviewer Checklist

- [ ] PR has a clear title and description
- [ ] Manually tested the changes that the PR introduces
- [ ] Changes introduced by the PR are covered by tests of acceptable quality
- [ ] Checked the quality of [commit messages](http://chris.beams.io/posts/git-commit/)