### PR TITLE
Add specialist columns to case study articles in Toby 

### DIFF
--- a/app/lib/toby/lookups/case_study/articles/specialist_name.rb
+++ b/app/lib/toby/lookups/case_study/articles/specialist_name.rb
@@ -1,0 +1,45 @@
+# frozen_string_literal: true
+
+module Toby
+  module Lookups
+    module CaseStudy
+      module Articles
+        class SpecialistName < Attributes::StringLookup
+          filter "contains...", Filters::StringContains do |records, _attribute, value|
+            if value.any? && value.first.present?
+              query = records.joins(specialist: :account)
+              names = value.first.split
+              names.each do |name|
+                query = query.where("accounts.first_name ILIKE ?", "%#{name}%").
+                  or(query.where("accounts.last_name ILIKE ?", "%#{name}%"))
+              end
+              query
+            else
+              records
+            end
+          end
+
+          def lazy_read_class
+            Toby::Lazy::Single
+          end
+
+          def includes
+            [:account]
+          end
+
+          def via
+            :specialist_id
+          end
+
+          def lazy_model
+            Specialist
+          end
+
+          def lazy_read(specialist)
+            specialist&.account&.name
+          end
+        end
+      end
+    end
+  end
+end

--- a/app/lib/toby/resources/case_study/article.rb
+++ b/app/lib/toby/resources/case_study/article.rb
@@ -7,6 +7,8 @@ module Toby
         model_name ::CaseStudy::Article
         attribute :uid, Attributes::String, readonly: true
         attribute :title, Attributes::String
+        attribute :specialist, Attributes::BelongsTo
+        attribute :specialist_name, Lookups::CaseStudy::Articles::SpecialistName
         attribute :deleted_at, Attributes::DateTime
 
         action :create_guild_post, label: "Post To Guild"


### PR DESCRIPTION
Resolves: [Add specialist columns to case study articles in Toby ](https://app.asana.com/0/1200808264546087/1201084868851941/f)

### Description

- [x] Add specialist belongs to column
- [x] Add additional specialist name lookup column which should have a filter to search by their name.

### Reviewer Checklist

- [ ] PR has a clear title and description
- [ ] Manually tested the changes that the PR introduces
- [ ] Changes introduced by the PR are covered by tests of acceptable quality
- [ ] Checked the quality of [commit messages](http://chris.beams.io/posts/git-commit/)