### PR TITLE
Change the sorting order of the events in Guild event page

### DIFF
--- a/app/models/event.rb
+++ b/app/models/event.rb
@@ -31,9 +31,8 @@ class Event < ApplicationRecord
       Arel.sql("
         CASE
           WHEN featured = true THEN 0
-          WHEN starts_at > NOW() THEN 1
-          ELSE 2
-        END, starts_at ASC")
+          ELSE 1
+        END, starts_at DESC")
     )
   }
   scope :upcoming, -> { where(ends_at: (Time.zone.now..)) }

--- a/spec/models/event_spec.rb
+++ b/spec/models/event_spec.rb
@@ -52,7 +52,7 @@ RSpec.describe Event, type: :model do
       expect(described_class.list).to include(in_progress)
     end
 
-    it "orders by featured first, asc upcoming second, and asc ended last" do
+    it "orders by featured first, asc upcoming second" do
       upcoming1 = create(:event, starts_at: 1.day.from_now, ends_at: 2.days.from_now)
       upcoming2 = create(:event, starts_at: 2.days.from_now, ends_at: 3.days.from_now)
       ended1 = create(:event, starts_at: 3.days.ago, ends_at: 2.days.ago)
@@ -61,7 +61,7 @@ RSpec.describe Event, type: :model do
 
       expect(described_class.list).to eq(
         [
-          featured, upcoming1, upcoming2, ended1, ended2
+          featured, upcoming2, upcoming1, ended2, ended1
         ]
       )
     end


### PR DESCRIPTION
Resolves: [Change the sorting order of the events in Guild event page](https://app.asana.com/0/1200808264546087/1201094558663626)

### Description

Simplified CASE while at it.

### Reviewer Checklist

- [ ] PR has a clear title and description
- [ ] Manually tested the changes that the PR introduces
- [ ] Changes introduced by the PR are covered by tests of acceptable quality
- [ ] Checked the quality of [commit messages](http://chris.beams.io/posts/git-commit/)