### PR TITLE
Make account_id index unique

### DIFF
--- a/app/models/specialist.rb
+++ b/app/models/specialist.rb
@@ -161,7 +161,7 @@ end
 #
 # Indexes
 #
-#  index_specialists_on_account_id      (account_id)
+#  index_specialists_on_account_id      (account_id) UNIQUE
 #  index_specialists_on_airtable_id     (airtable_id)
 #  index_specialists_on_country_id      (country_id)
 #  index_specialists_on_interviewer_id  (interviewer_id)

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -144,7 +144,7 @@ end
 #
 # Indexes
 #
-#  index_users_on_account_id   (account_id)
+#  index_users_on_account_id   (account_id) UNIQUE
 #  index_users_on_airtable_id  (airtable_id)
 #  index_users_on_company_id   (company_id)
 #  index_users_on_country_id   (country_id)

--- a/db/migrate/20210930132336_add_unique_index_to_specialists_and_users.rb
+++ b/db/migrate/20210930132336_add_unique_index_to_specialists_and_users.rb
@@ -1,0 +1,12 @@
+# frozen_string_literal: true
+
+class AddUniqueIndexToSpecialistsAndUsers < ActiveRecord::Migration[6.1]
+  def change
+    safety_assured do
+      remove_index :specialists, :account_id
+      add_index :specialists, :account_id, unique: true
+      remove_index :users, :account_id
+      add_index :users, :account_id, unique: true
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2021_09_28_064735) do
+ActiveRecord::Schema.define(version: 2021_09_30_132336) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "citext"
@@ -1042,7 +1042,7 @@ ActiveRecord::Schema.define(version: 2021_09_28_064735) do
     t.string "twitter"
     t.string "instagram"
     t.string "medium"
-    t.index ["account_id"], name: "index_specialists_on_account_id"
+    t.index ["account_id"], name: "index_specialists_on_account_id", unique: true
     t.index ["airtable_id"], name: "index_specialists_on_airtable_id"
     t.index ["country_id"], name: "index_specialists_on_country_id"
     t.index ["interviewer_id"], name: "index_specialists_on_interviewer_id"
@@ -1157,7 +1157,7 @@ ActiveRecord::Schema.define(version: 2021_09_28_064735) do
     t.uuid "company_id"
     t.datetime "application_interview_starts_at"
     t.string "trustpilot_review_status"
-    t.index ["account_id"], name: "index_users_on_account_id"
+    t.index ["account_id"], name: "index_users_on_account_id", unique: true
     t.index ["airtable_id"], name: "index_users_on_airtable_id"
     t.index ["company_id"], name: "index_users_on_company_id"
     t.index ["country_id"], name: "index_users_on_country_id"


### PR DESCRIPTION
### Description

Lifted from https://github.com/advisablecom/Advisable/pull/1462/files to simplify that one and to catch potential problems early.

There should be no issues from production:

```
[6] pry(main)> User.select(:account_id).group(:account_id).having("count(*) > 1").to_a
=> []
[7] pry(main)> Specialist.select(:account_id).group(:account_id).having("count(*) > 1").to_a
=> []
```

### Reviewer Checklist

- [ ] PR has a clear title and description
- [ ] Manually tested the changes that the PR introduces
- [ ] Changes introduced by the PR are covered by tests of acceptable quality
- [ ] Checked the quality of [commit messages](http://chris.beams.io/posts/git-commit/)

