### PR TITLE
Oauth failure is a debug-level message

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -82,6 +82,7 @@ Style/MethodCallWithArgsParentheses:
     - to
     - not_to
     - render
+    - redirect_to
     - raise
     - head
     - describe

--- a/app/controllers/auth_providers_controller.rb
+++ b/app/controllers/auth_providers_controller.rb
@@ -16,7 +16,7 @@ class AuthProvidersController < ApplicationController
       params = URI.decode_www_form(uri.query || "") << ["authorization_failed", "Authorization failed. Please try again."]
       uri.query = URI.encode_www_form(params.to_h)
     else
-      Sentry.capture_message("Something went wrong when with oauth.")
+      Sentry.capture_message("Something went wrong when authorizing with oauth.", level: "debug")
       uri = "/"
     end
 


### PR DESCRIPTION
### Description

Saw one in Sentry. Don't think we should bother with them unless it's for debug reasons.

### Reviewer Checklist

- [ ] PR has a clear title and description
- [ ] Manually tested the changes that the PR introduces
- [ ] Changes introduced by the PR are covered by tests of acceptable quality
- [ ] Checked the quality of [commit messages](http://chris.beams.io/posts/git-commit/)