### PR TITLE
Handle cases when freelancer bio is null on new profiles.

### DIFF
--- a/app/javascript/src/views/FreelancerProfile/components/Sidebar/index.js
+++ b/app/javascript/src/views/FreelancerProfile/components/Sidebar/index.js
@@ -34,10 +34,10 @@ export default function Sidebar({ data, ...props }) {
   const { specialist } = data;
 
   const [isExpanded, setExpanded] = useState(false);
-  const bioIsExceed = specialist.bio.length > TRUNCATE_LIMIT;
+  const bioIsExceed = specialist.bio?.length > TRUNCATE_LIMIT;
   const bio = isExpanded
     ? specialist.bio
-    : specialist.bio.slice(0, TRUNCATE_LIMIT);
+    : specialist.bio?.slice(0, TRUNCATE_LIMIT);
 
   return (
     <Box


### PR DESCRIPTION
Resolves: [Ticket](https://app.asana.com/0/1200808264546087/1201269621168157/f)

❗ This branch is supposed to be merged in `enable-new-profiles` branch

It makes sense to add an empty state for bio as a separate PR
![image](https://user-images.githubusercontent.com/849247/138852209-4bca4774-6ea6-4d11-a270-54a5342eccb9.png)

