### PR TITLE
Add helper for displaying base line grid overlay in app

### DIFF
--- a/app/javascript/src/Root.js
+++ b/app/javascript/src/Root.js
@@ -5,6 +5,7 @@ import { Elements } from "@stripe/react-stripe-js";
 import { Router } from "react-router-dom";
 import { ApolloProvider } from "@apollo/client";
 import client from "./graphqlClient";
+import BaseLineGridOverlay from "./components/BaseLineGridOverlay";
 
 const keys = JSON.parse(document.getElementById("keys").dataset.value);
 const stripePromise = loadStripe(keys.stripePublicKey);
@@ -17,6 +18,7 @@ const Root = ({ history }) => {
     <ApolloProvider client={client}>
       <Router history={history}>
         <Elements stripe={stripePromise}>
+          <BaseLineGridOverlay />
           <App />
         </Elements>
       </Router>

--- a/app/javascript/src/components/BaseLineGridOverlay.js
+++ b/app/javascript/src/components/BaseLineGridOverlay.js
@@ -1,0 +1,83 @@
+import React, { useEffect, useState } from "react";
+import { theme } from "@advisable/donut";
+import styled, { css } from "styled-components";
+
+const horizontal = css`
+  background-image: linear-gradient(
+    to bottom,
+    ${theme.colors.cyan600} 1px,
+    transparent 1px
+  );
+`;
+
+const veritcal = css`
+  background-image: linear-gradient(
+    to right,
+    ${theme.colors.cyan600} 1px,
+    transparent 1px
+  );
+`;
+
+const StyledBaselineGridOverlay = styled.div`
+  top: 0;
+  left: 0;
+  right: 0;
+  bottom: 0;
+  position: fixed;
+  z-index: 999999;
+  opacity: ${(p) => p.$opacity / 10};
+  background-size: ${(p) => `${p.$size}px ${p.$size}px`};
+  ${(p) => (p.$axis === "HORIZONTAL" ? horizontal : veritcal)};
+`;
+
+const NUMBER_KEYS = ["1", "2", "3", "4", "5", "6", "7", "8", "9"];
+
+export default function BaseLineGridOverlay() {
+  const [visible, setVisible] = useState(false);
+  const [axis, setAxis] = useState("HORIZONTAL");
+  const [size, setSize] = useState(4);
+  const [opacity, setOpacity] = useState(8);
+
+  useEffect(() => {
+    const handleKeyPress = (e) => {
+      if (e.code === "KeyG" && e.shiftKey && e.ctrlKey) {
+        e.preventDefault();
+        setVisible(!visible);
+      }
+
+      if (visible && e.key === "]") {
+        e.preventDefault();
+        setSize(size + 4);
+      }
+
+      if (visible && e.key === "[") {
+        e.preventDefault();
+        setSize(Math.abs(size - 4) || 4);
+      }
+
+      if (visible && e.key === "h") {
+        e.preventDefault();
+        setAxis("HORIZONTAL");
+      }
+
+      if (visible && e.key === "v") {
+        e.preventDefault();
+        setAxis("VERITCAL");
+      }
+
+      if (visible && NUMBER_KEYS.includes(e.key)) {
+        e.preventDefault();
+        setOpacity(Number(e.key));
+      }
+    };
+
+    window.addEventListener("keydown", handleKeyPress);
+    return () => window.removeEventListener("keydown", handleKeyPress);
+  });
+
+  if (!visible) return null;
+
+  return (
+    <StyledBaselineGridOverlay $opacity={opacity} $axis={axis} $size={size} />
+  );
+}


### PR DESCRIPTION
Adds helper for displaying grid overlay in app to improve alignment when building out pages.

## How dis works?

Everything is controlled via keyboard shortcuts

Toggle the grid on and off with `Ctrl + shift + g`.
Increase the size of the grid with `]`.
Decrease the size of the grid with `[`.
Switch between horizontal and vertical grids with `h` and `v` keys.
Set the opacity of the grid with the number keys.

![image](https://user-images.githubusercontent.com/1512593/139069591-96a7bb31-1099-40b9-9a81-d75476b1280a.png)

### Reviewer Checklist

- [ ] PR has a clear title and description
- [ ] Manually tested the changes that the PR introduces
- [ ] Changes introduced by the PR are covered by tests of acceptable quality
- [ ] Checked the quality of [commit messages](http://chris.beams.io/posts/git-commit/)
