### PR TITLE
Fix filtering of testimonials

### DIFF
--- a/app/javascript/src/views/FreelancerProfile/components/Testimonials.js
+++ b/app/javascript/src/views/FreelancerProfile/components/Testimonials.js
@@ -13,9 +13,9 @@ export default function Testimonials({ reviews }) {
   const { id } = useParams();
   const viewer = useViewer();
 
-  const testimonials = reviews.map(
-    (r) => !!r.comment && <Testimonial key={r.id} review={r} />,
-  );
+  const testimonials = reviews
+    .filter((r) => !!r.comment)
+    .map((r) => <Testimonial key={r.id} review={r} />);
 
   const isEmpty = testimonials.length === 0;
   const isOwner = viewer?.id === id;


### PR DESCRIPTION
### description

We still have a bug with testimonials. The title `testimonials` shouldn't be there. That happened because of the wrong usage of `map`.

⚠️  Bug:
![image](https://user-images.githubusercontent.com/849247/139418001-8b1045df-3ed3-42af-8ba6-72d489ce55dd.png)
