### PR TITLE
Only submit the values that have changed when making edits in Toby

### DIFF
--- a/app/javascript/toby/views/resource/DetailsModal/index.js
+++ b/app/javascript/toby/views/resource/DetailsModal/index.js
@@ -18,6 +18,7 @@ import {
 import { useMutation, useQuery } from "@apollo/client";
 import VersionHistory from "./VersionHistory";
 import ActionsMenu from "./ActionsMenu";
+import { isEqual } from "lodash-es";
 
 function useRoutedModal(path, returnPath) {
   const modal = useDialogState();
@@ -93,6 +94,16 @@ function Details({ id, resource }) {
   });
 
   const handleSubmit = async (attributes, formik) => {
+    const valuesToSubmit = Object.keys(initialValues).reduce((acc, key) => {
+      const initial = initialValues[key];
+      const value = attributes[key];
+      if (!isEqual(initial, value)) {
+        acc[key] = value;
+      }
+
+      return acc;
+    }, {});
+
     const { errors } = await update({
       variables: {
         id,
@@ -116,6 +127,9 @@ function Details({ id, resource }) {
       error("Failed to save record");
     } else {
       notify("Your changes have been saved");
+      formik.resetForm({
+        values: { ...initialValues, ...valuesToSubmit },
+      });
     }
   };
 


### PR DESCRIPTION
Resolves: [Ticket](https://sentry.io/organizations/advisable/issues/2783448414/?project=2021209&query=is%3Aunresolved)

### Description

Currently, when editing a record in Toby we are submitting all the values exactly as they are. With this change we only submit the values that have been edited. This will prevent situations where we might accidentally set values to "" that were previously nil. Or set a boolean to false that was previously nil.

### Reviewer Checklist

- [ ] PR has a clear title and description
- [ ] Manually tested the changes that the PR introduces
- [ ] Changes introduced by the PR are covered by tests of acceptable quality
- [ ] Checked the quality of [commit messages](http://chris.beams.io/posts/git-commit/)