### PR TITLE
Fix testimonial URL in prompt

### DIFF
--- a/app/javascript/src/views/FreelancerProfile/components/TestimonialLinkModal.js
+++ b/app/javascript/src/views/FreelancerProfile/components/TestimonialLinkModal.js
@@ -1,12 +1,8 @@
 import React from "react";
 import { Heading, Modal, Text, theme } from "@advisable/donut";
 import CopyURL from "src/components/CopyURL";
-import { useParams } from "react-router-dom";
 
-export default function TestimonialLinkModal({ modal }) {
-  const params = useParams();
-  const { id } = params;
-
+export default function TestimonialLinkModal({ specialist, modal }) {
   return (
     <Modal modal={modal} title="modal with a link to the testimonial flow">
       <Heading size="3xl" mb={3}>
@@ -18,7 +14,7 @@ export default function TestimonialLinkModal({ modal }) {
       </Text>
       <CopyURL
         bg={theme.colors.blue100}
-      >{`${location.origin}/review/${id}/`}</CopyURL>
+      >{`${location.origin}/review/${specialist.id}/`}</CopyURL>
     </Modal>
   );
 }

--- a/app/javascript/src/views/FreelancerProfile/components/Testimonials.js
+++ b/app/javascript/src/views/FreelancerProfile/components/Testimonials.js
@@ -7,7 +7,7 @@ import Testimonial from "./Testimonial";
 import TestimonialLinkModal from "./TestimonialLinkModal";
 import TestimonialsEmptyState from "./TestimonialsEmptyState";
 
-function Testimonials({ reviews, isOwner }) {
+function Testimonials({ reviews, specialist, isOwner }) {
   const modal = useModal();
 
   const testimonials = reviews
@@ -35,7 +35,7 @@ function Testimonials({ reviews, isOwner }) {
           Request a Testimonial
         </DialogDisclosure>
       )}
-      <TestimonialLinkModal modal={modal} />
+      <TestimonialLinkModal specialist={specialist} modal={modal} />
     </Box>
   );
 }


### PR DESCRIPTION
This was directing them to /review/undefined because the param is now called :username to account for the new usernames feature.

### Reviewer Checklist

- [ ] PR has a clear title and description
- [ ] Manually tested the changes that the PR introduces
- [ ] Changes introduced by the PR are covered by tests of acceptable quality
- [ ] Checked the quality of [commit messages](http://chris.beams.io/posts/git-commit/)
