### PR TITLE
Add case_study path field to have consistent urls

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -25,10 +25,8 @@ class ApplicationController < ActionController::Base
 
   def case_study
     @case_study = ::CaseStudy::Article.find_by_slug_or_id!(params[:id])
-    username = @case_study.specialist.username || @case_study.specialist.uid
-    slug = @case_study.slug || @case_study.uid
     Sentry.capture_message("Redirecting case study URL", level: "debug")
-    redirect_to "/freelancers/#{username}/#{slug}"
+    redirect_to @case_study.path
   end
 
   def set_sentry_context

--- a/app/graphql/types/case_study/article.rb
+++ b/app/graphql/types/case_study/article.rb
@@ -19,6 +19,8 @@ module Types
         dataloader.with(::ActiveRecordSource, ::CaseStudy::Company).load(object.company_id) if policy.read_company?
       end
 
+      field :path, String, null: false
+
       field :skills, [Skill], null: true
       def skills
         object.skills.order(created_at: :asc)

--- a/app/graphql/types/specialist_type.rb
+++ b/app/graphql/types/specialist_type.rb
@@ -16,6 +16,7 @@ module Types
     end
 
     field :username, String, null: true
+    field :profile_path, String, null: false
 
     field :airtable_id, String, null: true, deprecation_reason: "We're moving away from Airtable. Please stop using Airtable IDs." do
       description "The airtable ID for the specialist"

--- a/app/javascript/src/ApplicationRoutes.js
+++ b/app/javascript/src/ApplicationRoutes.js
@@ -45,7 +45,7 @@ const NewPost = lazy(() => import("./views/NewPost"));
 
 function RedirectToFreelancerProfile() {
   const viewer = useViewer();
-  return <Redirect to={`/freelancers/${viewer.username || viewer.id}`} />;
+  return <Redirect to={viewer.profilePath} />;
 }
 
 function RedirectToSetPassword() {

--- a/app/javascript/src/graphql/fragments/viewerFields.graphql
+++ b/app/javascript/src/graphql/fragments/viewerFields.graphql
@@ -29,6 +29,7 @@ fragment ViewerFields on ViewerUnion {
   }
   ... on Specialist {
     id
+    profilePath
     username
     email
     name

--- a/app/javascript/src/testHelpers/mockData.js
+++ b/app/javascript/src/testHelpers/mockData.js
@@ -194,6 +194,7 @@ export const specialist = (fields = {}) => {
     {
       __typename: "Specialist",
       id: uniqueId("specialist"),
+      profilePath: "/testspecialist",
       username: "testspecialist",
       bio: "Specialist bio",
       name: "Test Specialist",

--- a/app/javascript/src/views/FreelancerDashboard/components/Project.js
+++ b/app/javascript/src/views/FreelancerDashboard/components/Project.js
@@ -41,10 +41,7 @@ function Avatar({ avatar }) {
 export default function Project({ caseStudy }) {
   return (
     <Sentry.ErrorBoundary>
-      <Card
-        as={Link}
-        to={`/freelancers/${caseStudy.specialist?.id}/case_studies/${caseStudy.id}`}
-      >
+      <Card as={Link} to={caseStudy.path}>
         <Box display="flex" css={css({ columnGap: 4 })}>
           <Box
             position="relative"

--- a/app/javascript/src/views/FreelancerDashboard/queries/dashboardData.gql
+++ b/app/javascript/src/views/FreelancerDashboard/queries/dashboardData.gql
@@ -10,6 +10,7 @@ query DashboardData {
   }
   topCaseStudies {
     id
+    path
     title
     specialist {
       id

--- a/app/javascript/src/views/FreelancerProfile/components/CaseStudyCard.js
+++ b/app/javascript/src/views/FreelancerProfile/components/CaseStudyCard.js
@@ -7,7 +7,7 @@ import { motion } from "framer-motion";
 import styled from "styled-components";
 import { variant } from "styled-system";
 import SuperEllipse from "react-superellipse";
-import { matchPath, useParams } from "react-router";
+import { matchPath } from "react-router";
 import { Box, Text, Link, Skeleton, theme } from "@advisable/donut";
 import LogoMark from "src/components/LogoMark";
 
@@ -159,8 +159,6 @@ const CaseStudyBackgroundImage = React.memo(function CaseStudyBackgroundImage({
 });
 
 export default function CaseStudyCard({ caseStudy }) {
-  const params = useParams();
-
   const isArticle = !!matchPath(location.pathname, {
     path: "/freelancers/:username/:slug",
   });
@@ -171,11 +169,7 @@ export default function CaseStudyCard({ caseStudy }) {
 
   return (
     <Suspense fallback={<LoadingSkeleton />}>
-      <Box
-        as={isArticle ? null : Link}
-        to={`/freelancers/${params.username}/${caseStudy.slug || caseStudy.id}`}
-        notInline="true"
-      >
+      <Box as={isArticle ? null : Link} to={caseStudy.path} notInline="true">
         <StyledCaseStudyCard type={isArticle ? "article" : "profile"}>
           {caseStudy.coverPhoto ? (
             <Sentry.ErrorBoundary>

--- a/app/javascript/src/views/FreelancerProfile/queries/fragments/specialistFields.gql
+++ b/app/javascript/src/views/FreelancerProfile/queries/fragments/specialistFields.gql
@@ -25,6 +25,7 @@ fragment SpecialistFields on Specialist {
   caseStudies {
     id
     slug
+    path
     companyType
     title
     coverPhoto

--- a/app/models/case_study/article.rb
+++ b/app/models/case_study/article.rb
@@ -29,6 +29,14 @@ module CaseStudy
     scope :by_score, -> { order("score DESC NULLS LAST").order(id: :desc) }
     scope :available_specialists, -> { joins(:specialist).merge(Specialist.available).joins(specialist: :account).merge(Account.active) }
 
+    def slug_or_uid
+      slug || uid
+    end
+
+    def path
+      "/freelancers/#{specialist.username_or_uid}/#{slug_or_uid}"
+    end
+
     def self.find_by_slug_or_id(slug)
       if ::CaseStudy::Article.valid_uid?(slug)
         ::CaseStudy::Article.active.published.find_by(uid: slug)

--- a/app/models/specialist.rb
+++ b/app/models/specialist.rb
@@ -78,6 +78,14 @@ class Specialist < ApplicationRecord
     application_stage == "Accepted"
   end
 
+  def username_or_uid
+    username || uid
+  end
+
+  def profile_path
+    "/freelancers/#{username_or_uid}"
+  end
+
   def send_confirmation_email
     token = account.create_confirmation_token
     SpecialistMailer.confirm(uid: uid, token: token).deliver_later

--- a/app/views/specialists/case_study.html.erb
+++ b/app/views/specialists/case_study.html.erb
@@ -2,7 +2,7 @@
   <%# facebook  %>
   <meta property="og:type" content="article" />
   <meta property="og:title" content='<%= @case_study.title %>'% />
-  <meta property="og:url" content=<%= specialist_case_study_url(@case_study.specialist.username || @case_study.specialist.uid, @case_study.slug || @case_study.uid) %> />
+  <meta property="og:url" content=<%= specialist_case_study_url(@case_study.specialist.username_or_uid, @case_study.slug_or_uid) %> />
   <meta property="og:description" content='<%= @case_study.subtitle %>' />
   <meta property="article:published_time" content=<%= @case_study.created_at.strftime('%Y-%m-%d') %> />
   


### PR DESCRIPTION
There are quite a few places where we are constructing case study and profile URLs on the frontend. This adds a new `path` and `profilePath` field to the case study and specialist types so that the frontend can use that to ensure consistent paths everywhere.

### Reviewer Checklist

- [ ] PR has a clear title and description
- [ ] Manually tested the changes that the PR introduces
- [ ] Changes introduced by the PR are covered by tests of acceptable quality
- [ ] Checked the quality of [commit messages](http://chris.beams.io/posts/git-commit/)