### PR TITLE
Fix payment retrying and improve Slack messages

### DIFF
--- a/app/lib/toby/resources/payment.rb
+++ b/app/lib/toby/resources/payment.rb
@@ -34,7 +34,7 @@ module Toby
       def self.retry_payment(object, _context)
         return if object.status == "succeeded"
 
-        object.update!(retries: object.retries + 1)
+        object.update!(retries: object.retries + 1, payment_intent_id: nil)
         object.charge!
       end
 


### PR DESCRIPTION
Resolves: [Ticket](URL)

### Description

- make stripe payment_id `nil` so it's actually retried
- make slack messages clearer

### Reviewer Checklist

- [ ] PR has a clear title and description
- [ ] Manually tested the changes that the PR introduces
- [ ] Changes introduced by the PR are covered by tests of acceptable quality
- [ ] Checked the quality of [commit messages](http://chris.beams.io/posts/git-commit/)