### PR TITLE
Fix incircle icons in profile empty states

### DIFF
--- a/app/javascript/src/views/FreelancerProfile/components/CaseStudiesEmptyState.js
+++ b/app/javascript/src/views/FreelancerProfile/components/CaseStudiesEmptyState.js
@@ -31,6 +31,8 @@ export default function CaseStudiesEmptyState({ specialist }) {
           Showcase your work and find new clients.
         </Text>
         <Circle
+          mx="auto"
+          display="block"
           border="2px solid"
           borderColor="neutral200"
           color="neutral200"

--- a/app/javascript/src/views/FreelancerProfile/components/TestimonialsEmptyState.js
+++ b/app/javascript/src/views/FreelancerProfile/components/TestimonialsEmptyState.js
@@ -29,6 +29,8 @@ export default function TestimonialsEmptyState({ modal }) {
           you.
         </Text>
         <Circle
+          mx="auto"
+          display="block"
           border="2px solid"
           borderColor="neutral200"
           color="neutral200"

--- a/donut/src/components/Circle/styles.js
+++ b/donut/src/components/Circle/styles.js
@@ -1,3 +1,4 @@
+import { display } from "styled-system";
 import styled from "styled-components";
 import StyledBox from "../Box/styles";
 
@@ -6,6 +7,7 @@ export const StyledCircle = styled(StyledBox)`
   align-items: center;
   display: inline-flex;
   justify-content: center;
+  ${display}
 `;
 
 export default StyledCircle;


### PR DESCRIPTION
Resolves: [Ticket](https://app.asana.com/0/1200808264546087/1201375180436130/f)

### Description

In Safari we have some weird bug with `Circle` caused by `display: inline-flex` prop. The solution is to override it as `block`. Not sure if that's the only instance where it works badly.
### Screenshots

Before                           | After
-------------------------------- | --------------------------------
<img width="753" alt="image" src="https://user-images.githubusercontent.com/849247/142467316-52b8aaa8-2f65-4730-9c6c-1e5d7f685e3b.png"> | <img width="779" alt="image" src="https://user-images.githubusercontent.com/849247/142467372-83311813-188b-4723-989b-5e2b38735fa6.png">

