### PR TITLE
Add functionality to resize columns inside of Toby

### DIFF
--- a/app/javascript/toby/attributes/index.js
+++ b/app/javascript/toby/attributes/index.js
@@ -42,7 +42,7 @@ export function Attribute({ record, attribute, ...props }) {
   const handler = handlerForAttribute(attribute);
 
   if (!handler) {
-    console.error("No attribute handler found", attribute);
+    // console.error("No attribute handler found", attribute);
     return <div>{record[attribute.name]}</div>;
   }
 

--- a/app/javascript/toby/styles.js
+++ b/app/javascript/toby/styles.js
@@ -49,6 +49,7 @@ export const StyledHeaderRow = styled.div`
   display: flex;
   position: sticky;
   flex-wrap: nowrap;
+  user-select: none;
   white-space: nowrap;
   background-color: ${theme.colors.neutral50};
   box-shadow: 0 2px 4px ${rgba(theme.colors.neutral900, 0.16)},
@@ -56,18 +57,44 @@ export const StyledHeaderRow = styled.div`
 `;
 
 export const StyledHeaderCell = styled.div`
-  width: 200px;
   height: 36px;
   display: inline-flex;
   flex-shrink: 0;
   padding: 0 10px;
   font-size: 15px;
-  overflow: hidden;
   font-weight: 500;
   white-space: nowrap;
   align-items: center;
+  position: relative;
   color: ${theme.colors.neutral900};
   border-right: 1px solid ${theme.colors.neutral200};
+`;
+
+export const StyledResizeHandler = styled.div`
+  top: 0;
+  width: 20px;
+  right: -10px;
+  height: 100%;
+  cursor: ew-resize;
+  position: absolute;
+  z-index: 2;
+
+  &::after {
+    content: "";
+    width: 3px;
+    opacity: 0;
+    display: block;
+    margin-top: 4px;
+    margin-left: 9px;
+    border-radius: 2px;
+    height: calc(100% - 8px);
+    background: ${theme.colors.neutral400};
+  }
+
+  &:hover::after,
+  &[data-resizing="true"]:after {
+    opacity: 1;
+  }
 `;
 
 export const StyledRow = styled.div`
@@ -89,7 +116,6 @@ export const StyledCellCopyButton = styled.button`
 `;
 
 export const StyledCell = styled.div`
-  width: 200px;
   height: 40px;
   display: flex;
   font-size: 15px;

--- a/app/javascript/toby/views/resource/Loading.js
+++ b/app/javascript/toby/views/resource/Loading.js
@@ -2,9 +2,9 @@ import React from "react";
 import { Skeleton } from "@advisable/donut";
 import { StyledRow, StyledCell } from "../../styles";
 
-export default function Loading({ resource }) {
+export default function Loading({ resource, sizeForColumn }) {
   const cells = resource.attributes.map((attr) => (
-    <StyledCell key={attr.name}>
+    <StyledCell key={attr.name} style={{ width: sizeForColumn(attr.name) }}>
       <Skeleton width={120} height={20} />
     </StyledCell>
   ));

--- a/app/javascript/toby/views/resource/Records.js
+++ b/app/javascript/toby/views/resource/Records.js
@@ -8,9 +8,11 @@ import {
   StyledHeaderRow,
   StyledHeaderCell,
   StyledScrollContainer,
+  StyledResizeHandler,
 } from "../../styles";
 import Rows from "./Rows";
 import Loading from "./Loading";
+import useColumnSizes from "./useColumnSizes";
 
 function APIError() {
   return (
@@ -29,6 +31,7 @@ function APIError() {
 }
 
 export default function Records({ resource, filters, sortBy, sortOrder }) {
+  const { sizeForColumn, resizePropsForHeaderCell } = useColumnSizes(resource);
   const { error: notifyError } = useNotifications();
   const { loading, data, fetchMore, error } = useFetchResources(
     resource,
@@ -56,14 +59,37 @@ export default function Records({ resource, filters, sortBy, sortOrder }) {
       <Box display="inline-block" minWidth="100vw">
         <StyledHeaderRow>
           {resource.attributes.map((attr) => (
-            <StyledHeaderCell key={attr.name}>
-              {attr.columnLabel}
+            <StyledHeaderCell
+              style={{
+                width: sizeForColumn(attr.name),
+              }}
+              key={attr.name}
+            >
+              <Text
+                paddingY={1}
+                fontWeight={500}
+                letterSpacing="-0.01rem"
+                $truncate
+              >
+                {attr.columnLabel}
+              </Text>
+              <StyledResizeHandler {...resizePropsForHeaderCell(attr.name)} />
             </StyledHeaderCell>
           ))}
         </StyledHeaderRow>
         <Box>
-          {error ? <APIError /> : <Rows edges={edges} resource={resource} />}
-          {loading && <Loading resource={resource} />}
+          {error ? (
+            <APIError />
+          ) : (
+            <Rows
+              edges={edges}
+              resource={resource}
+              sizeForColumn={sizeForColumn}
+            />
+          )}
+          {loading && (
+            <Loading resource={resource} sizeForColumn={sizeForColumn} />
+          )}
         </Box>
       </Box>
     </StyledScrollContainer>

--- a/app/javascript/toby/views/resource/Rows.js
+++ b/app/javascript/toby/views/resource/Rows.js
@@ -8,7 +8,7 @@ import { StyledRow, StyledCell } from "../../styles";
 import { recordPath } from "../../utilities";
 import CopyToClipboard from "../../components/CopyToClipboard";
 
-export default function Rows({ edges, resource }) {
+export default function Rows({ edges, resource, sizeForColumn }) {
   const history = useHistory();
 
   const openRecord = (record) => () => {
@@ -21,7 +21,7 @@ export default function Rows({ edges, resource }) {
   return edges.map(({ node }) => (
     <StyledRow key={node.id} onClick={openRecord(node)}>
       {resource.attributes.map((attr) => (
-        <StyledCell key={attr.name}>
+        <StyledCell style={{ width: sizeForColumn(attr.name) }} key={attr.name}>
           <Sentry.ErrorBoundary
             fallback={
               <Box display="inline-flex" alignItems="center">

--- a/app/javascript/toby/views/resource/useColumnSizes.js
+++ b/app/javascript/toby/views/resource/useColumnSizes.js
@@ -1,0 +1,81 @@
+import { throttle } from "lodash-es";
+import { useCallback, useEffect, useRef, useState } from "react";
+
+function getStoredSizes(resource) {
+  const existing = localStorage.getItem(`${resource.type}_Sizes`) || "{}";
+  return JSON.parse(existing);
+}
+
+function storeSizes(resource, sizes) {
+  localStorage.setItem(`${resource.type}_Sizes`, JSON.stringify(sizes));
+}
+
+function getSizesForResource(resource) {
+  return resource.attributes.reduce((sizes, attribute) => {
+    const existing = getStoredSizes(resource);
+    sizes[attribute.name] = existing[attribute.name] || 200;
+    return sizes;
+  }, {});
+}
+
+export default function useColumnSizes(resource) {
+  const resizingRef = useRef(null);
+  const [resizingAttr, setResizingAttr] = useState(null);
+  const [sizes, setSizes] = useState(() => {
+    return getSizesForResource(resource);
+  });
+
+  const resizeColumn = useCallback((name, size) => {
+    setSizes((existing) => {
+      return { ...existing, [name]: size };
+    });
+  }, []);
+
+  const sizeForColumn = useCallback((name) => sizes[name], [sizes]);
+
+  const resizePropsForHeaderCell = useCallback(
+    (attr) => {
+      return {
+        "data-resizing": resizingAttr === attr,
+        onMouseDown: (e) => {
+          setResizingAttr(attr);
+          const initial = getStoredSizes(resource)[attr];
+          resizingRef.current = { initial: initial, x: e.clientX };
+        },
+      };
+    },
+    [resizingAttr, resource],
+  );
+
+  const mouseMove = useCallback(
+    (e) => {
+      if (!resizingRef.current) return;
+      const initial = resizingRef.current.initial;
+      const delta = e.clientX - resizingRef.current.x;
+      const newSize = initial + delta;
+      resizeColumn(resizingAttr, Math.max(120, newSize));
+    },
+    [resizingAttr, resizeColumn],
+  );
+
+  const mouseUp = useCallback(() => {
+    setResizingAttr(null);
+    resizingRef.current = null;
+  }, []);
+
+  useEffect(() => {
+    storeSizes(resource, sizes);
+  }, [resource, sizes]);
+
+  useEffect(() => {
+    const mouseMoveThrottled = throttle(mouseMove, 50);
+    window.addEventListener("mousemove", mouseMoveThrottled);
+    window.addEventListener("mouseup", mouseUp);
+    return () => {
+      window.removeEventListener("mousemove", mouseMoveThrottled);
+      window.removeEventListener("mouseup", mouseUp);
+    };
+  }, [mouseMove, mouseUp]);
+
+  return { sizeForColumn, resizePropsForHeaderCell };
+}


### PR DESCRIPTION
Resolves: [Ticket](https://app.asana.com/0/1200808264546087/1201373842485320/f)

Adds ability to resize columns in Toby by clicking and dragging on the header cell edges. It also stores the sizes inside of local storage so that they persist across page refreshes and sessions.

![CleanShot 2021-11-19 at 16 36 43](https://user-images.githubusercontent.com/1512593/142658818-1be19a2b-9fbb-4938-a6cb-297488682392.gif)


### Reviewer Checklist

- [ ] PR has a clear title and description
- [ ] Manually tested the changes that the PR introduces
- [ ] Changes introduced by the PR are covered by tests of acceptable quality
- [ ] Checked the quality of [commit messages](http://chris.beams.io/posts/git-commit/)