### PR TITLE
Fix combobox not opening on focus

### DIFF
--- a/donut/src/components/Combobox/Desktop.js
+++ b/donut/src/components/Combobox/Desktop.js
@@ -18,6 +18,7 @@ export default function ComboboxDesktop({
   ...props
 }) {
   const popper = React.useRef(null);
+  const comboboxRef = React.useRef(null);
   const inputConatinerRef = React.useRef(null);
   const listboxContainerRef = React.useRef(null);
 
@@ -51,20 +52,20 @@ export default function ComboboxDesktop({
   }, [menuProps]);
 
   useEffect(() => {
+    const container = comboboxRef.current;
+
     const handleClick = (e) => {
-      const container = listboxContainerRef.current;
       if (!container) return;
       if (!container.contains(e.target)) {
         close();
       }
     };
-
-    document.addEventListener("click", handleClick);
-    return () => document.removeEventListener("click", handleClick);
-  }, [close]);
+    document.body.addEventListener("click", handleClick);
+    return () => document.body.removeEventListener("click", handleClick);
+  }, [isOpen, close]);
 
   return (
-    <StyledAutocomplete {...containerProps}>
+    <StyledAutocomplete ref={comboboxRef} {...containerProps}>
       <div ref={inputConatinerRef}>
         <Input {...inputProps()} suffix={<ChevronDown />} />
       </div>


### PR DESCRIPTION
Resolves: [Ticket](https://app.asana.com/0/1200808264546087/1201411192363624/f)

This was because the on click outside of the popup event was happening when you clicked to focus on the input.

### Reviewer Checklist

- [ ] PR has a clear title and description
- [ ] Manually tested the changes that the PR introduces
- [ ] Changes introduced by the PR are covered by tests of acceptable quality
- [ ] Checked the quality of [commit messages](http://chris.beams.io/posts/git-commit/)