### PR TITLE
Fix positioning of FreelancerJoin content

### DIFF
--- a/app/javascript/src/views/FreelancerJoin/OrbitsContent/index.js
+++ b/app/javascript/src/views/FreelancerJoin/OrbitsContent/index.js
@@ -98,7 +98,6 @@ export default function OrbitsContent({ step, custom }) {
       alignSelf={{ _: "start", xl: "center" }}
       maxWidth={{ _: "640px", xl: "500px" }}
       pr={{ _: 0, xl: 8 }}
-      p={{ _: 0, xl: 14 }}
       pb={{ xl: 14 }}
       display="flex"
       flexDirection="column"


### PR DESCRIPTION
### Description

Quick fix to revert my mistake while updating copies in Join flow

# Before:
<img width="1286" alt="image" src="https://user-images.githubusercontent.com/849247/143425665-d53f35e5-8ec9-4e43-bc72-5b652f9dacdc.png">

# After:
<img width="1343" alt="image" src="https://user-images.githubusercontent.com/849247/143425918-7949da22-aee0-474b-b0f6-b6fc60592702.png">
