### PR TITLE
Handle cases when user availability is nil

### DIFF
--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -52,7 +52,7 @@ class User < ApplicationRecord
   end
 
   def availability
-    super.select(&:future?)
+    (super.presence || []).select(&:future?)
   end
 
   def accepted?

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -11,14 +11,23 @@ RSpec.describe(User, type: :model) do
     expect(build(:user)).to be_valid
   end
 
-  it "shows only availabilities in the future" do
-    user = create(:user)
-    past = 1.day.ago.change({hour: 10, min: 0, sec: 0})
-    future = 1.day.from_now.change({hour: 10, min: 0, sec: 0})
-    user.update(availability: [past, future])
-    expect(user.read_attribute(:availability)).to match_array([past, future])
-    expect(user.availability).not_to include(past)
-    expect(user.availability).to include(future)
+  describe "#availability" do
+    it "shows only availabilities in the future" do
+      user = create(:user)
+      past = 1.day.ago.change({hour: 10, min: 0, sec: 0})
+      future = 1.day.from_now.change({hour: 10, min: 0, sec: 0})
+      user.update(availability: [past, future])
+      expect(user.read_attribute(:availability)).to match_array([past, future])
+      expect(user.availability).not_to include(past)
+      expect(user.availability).to include(future)
+    end
+
+    context "when new user" do
+      it "returns blank array" do
+        user = described_class.new
+        expect(user.availability).to eq([])
+      end
+    end
   end
 
   describe "#name_with_company" do


### PR DESCRIPTION
The user's availability will be nil when the account is first created and this leads to an error when fetching from the API.

```
private method `select' called for nil:NilClass
```

### Reviewer Checklist

- [ ] PR has a clear title and description
- [ ] Manually tested the changes that the PR introduces
- [ ] Changes introduced by the PR are covered by tests of acceptable quality
- [ ] Checked the quality of [commit messages](http://chris.beams.io/posts/git-commit/)