### PR TITLE
Fix importing editor_url from airtable

### DIFF
--- a/app/lib/airtable/case_study.rb
+++ b/app/lib/airtable/case_study.rb
@@ -41,7 +41,7 @@ module Airtable
         article = ::CaseStudy::Article.find_or_initialize_by(airtable_id: id)
 
         article.specialist = ::Specialist.find_by!(airtable_id: fields["Specialist"].first)
-        article.editor_url = fields["Case Study Editor Link"]
+        article.editor_url = fields["Case Study Editor Link"].first
 
         if fields["Interviewer"].present?
           sales_person = ::SalesPerson.find_by!(airtable_id: fields["Interviewer"])


### PR DESCRIPTION
[Ticket](https://app.asana.com/0/1200808264546087/1201444461107369/f)

The column is a lookup inside of Airtable which returns an array. These were all getting synced as "[\"url\"]". I have resynced the URL for all existing case studies in production to the correct value.

### Reviewer Checklist

- [ ] PR has a clear title and description
- [ ] Manually tested the changes that the PR introduces
- [ ] Changes introduced by the PR are covered by tests of acceptable quality
- [ ] Checked the quality of [commit messages](http://chris.beams.io/posts/git-commit/)