### PR TITLE
Set Apollo client credentials to same-origin

### DIFF
--- a/app/javascript/src/graphqlClient.js
+++ b/app/javascript/src/graphqlClient.js
@@ -39,6 +39,7 @@ const authLink = setContext((_, { headers }) => {
 
 const httpLink = createHttpLink({
   uri: "/graphql",
+  credentials: "same-origin",
 });
 
 const retryLink = new RetryLink({


### PR DESCRIPTION
Forgot to include this in the other PR. Still getting a few CSRF issues so maybe this will do something? 🤷 

### Reviewer Checklist

- [ ] PR has a clear title and description
- [ ] Manually tested the changes that the PR introduces
- [ ] Changes introduced by the PR are covered by tests of acceptable quality
- [ ] Checked the quality of [commit messages](http://chris.beams.io/posts/git-commit/)
