### PR TITLE
Process image in the background

### DIFF
--- a/app/jobs/process_image_job.rb
+++ b/app/jobs/process_image_job.rb
@@ -1,0 +1,7 @@
+# frozen_string_literal: true
+
+class ProcessImageJob < ApplicationJob
+  def perform(image, options)
+    image.variant(options).process
+  end
+end

--- a/app/models/concerns/resizable.rb
+++ b/app/models/concerns/resizable.rb
@@ -63,7 +63,12 @@ module Resizable
     return if image.blank?
 
     if image.respond_to?(:variation)
-      Rails.application.routes.url_helpers.rails_representation_url(image, host: Advisable::Application::ORIGIN_HOST)
+      if image.processed?
+        Rails.application.routes.url_helpers.rails_representation_url(image, host: Advisable::Application::ORIGIN_HOST)
+      else
+        ProcessImageJob.perform_later(image.blob, image.variation.transformations)
+        Rails.application.routes.url_helpers.rails_blob_url(image.blob, host: Advisable::Application::ORIGIN_HOST)
+      end
     else
       Rails.application.routes.url_helpers.rails_blob_url(image, host: Advisable::Application::ORIGIN_HOST)
     end


### PR DESCRIPTION
### Description

This should fix/avoid long request times when a variation is requested the first time.

Now we basically have a conditional:
- if we have the variation we return it
- if we don't we enqueue processing on a bg task, and return original

### Reviewer Checklist

- [ ] PR has a clear title and description
- [ ] Manually tested the changes that the PR introduces
- [ ] Changes introduced by the PR are covered by tests of acceptable quality
- [ ] Checked the quality of [commit messages](http://chris.beams.io/posts/git-commit/)