### PR TITLE
Fix composer remounting on new message

### DIFF
--- a/app/javascript/src/views/Messages/components/ConversationMessages.js
+++ b/app/javascript/src/views/Messages/components/ConversationMessages.js
@@ -90,20 +90,17 @@ export default function ConversationMessages({ conversation, currentAccount }) {
                 <Box flexShrink={1} height="1px" width="100%" bg="neutral200" />
               </Box>
             )}
-            <Stack
-              paddingY={10}
-              spacing={10}
-              divider="neutral100"
-              id="messages"
-            >
-              {messageEdges.map((edge) => (
-                <Message key={edge.node.id} message={edge.node} />
-              ))}
+            <Box paddingY={8}>
+              <Stack spacing={6} id="messages" paddingBottom={6}>
+                {messageEdges.map((edge) => (
+                  <Message key={edge.node.id} message={edge.node} />
+                ))}
+              </Stack>
               <MessageComposer
                 conversation={conversation}
                 currentAccount={currentAccount}
               />
-            </Stack>
+            </Box>
           </Box>
         )}
       </Box>


### PR DESCRIPTION
Resolves: [Ticket](https://app.asana.com/0/1200808264546087/1201463972005716/f)

### Description

This was something I discovered while building out the new consultation request messages. Due to the way that the Stack component works it was remounting the MessageComposer component every time it rendered. Which meant that any time a new message was sent it would re-render. This would result in a bug where if I was writing a message and the other user sent a message while I was writing it, it would remount, clearing out the state and loosing the message I was writing.

### Reviewer Checklist

- [ ] PR has a clear title and description
- [ ] Manually tested the changes that the PR introduces
- [ ] Changes introduced by the PR are covered by tests of acceptable quality
- [ ] Checked the quality of [commit messages](http://chris.beams.io/posts/git-commit/)