### PR TITLE
Refresh conversation data on load

### DIFF
--- a/app/javascript/src/views/Messages/components/ConversationMessages.js
+++ b/app/javascript/src/views/Messages/components/ConversationMessages.js
@@ -16,6 +16,7 @@ export default function ConversationMessages({ conversation, currentAccount }) {
   useUpdateConversationLastRead(conversation);
   const { data, loading, fetchMore, refetch } = useMessages({
     pollInterval: POLL,
+    fetchPolicy: "cache-and-network",
     notifyOnNetworkStatusChange: true,
     variables: { id: conversation.id },
   });


### PR DESCRIPTION
Another weird edge case with messages. If a user opened a conversation and then navigated to another page they will have loaded the conversation data into their cache, however, as they have left the conversation view they are no longer subscribed to new messages. This means that if they receive a message while they were on another page, the conversation data would not be updated and when they went back to the conversation it would not have updated.

Another solution to this problem would be to move the message subscription hook to the root of the app so that they would be notified of new messages no matter what page they are on. However, this would mean we would be creating a web socket connection for every authenticated user rather than just those viewing conversations which i'm not sure is worth it. Most of these messages are async non instant messaging style messages.

### Reviewer Checklist

- [ ] PR has a clear title and description
- [ ] Manually tested the changes that the PR introduces
- [ ] Changes introduced by the PR are covered by tests of acceptable quality
- [ ] Checked the quality of [commit messages](http://chris.beams.io/posts/git-commit/)