### PR TITLE
Improve Uid and Slug concerns

### DIFF
--- a/app/models/concerns/sluggable.rb
+++ b/app/models/concerns/sluggable.rb
@@ -20,11 +20,12 @@ module Sluggable
   end
 
   included do
-    before_validation :set_slug
-    validates :slug, uniqueness: true
+    before_validation :generate_slug
   end
 
-  def set_slug
+  private
+
+  def generate_slug
     return if slug.present?
 
     self.slug = unique_slug
@@ -32,15 +33,11 @@ module Sluggable
 
   def unique_slug
     slug = public_send(self.class.slug_source).to_s.parameterize
-    return slug unless slug_taken?(slug)
+    return slug unless self.class.exists?(slug: slug)
 
     (2..).each do |i|
       new_slug = "#{slug}-#{i}"
-      break new_slug unless slug_taken?(new_slug)
+      break new_slug unless self.class.exists?(slug: new_slug)
     end
-  end
-
-  def slug_taken?(slug)
-    self.class.exists?(slug: slug)
   end
 end

--- a/app/models/concerns/uid.rb
+++ b/app/models/concerns/uid.rb
@@ -5,27 +5,6 @@
 module Uid
   extend ActiveSupport::Concern
 
-  included do
-    before_validation :generate_uid, on: :create, unless: :uid?
-    validates :uid, presence: true
-    validates :uid, uniqueness: true, on: :create
-    validate :valid_uid, on: :create
-
-    private
-
-    def generate_uid
-      self.uid = self.class.generate_uid
-    end
-
-    def valid_uid
-      return unless uid
-
-      prefix, uniq = uid.split("_")
-      errors.add(:base, "invalid_id_prefix") if prefix != self.class.prefix_for_uid
-      errors.add(:base, "id_too_short") if uniq.length != 15
-    end
-  end
-
   class_methods do
     # self.uid_prefix can be used to override the prefix for the uid.
     # by default it will be the first three characters of the class.
@@ -51,5 +30,31 @@ module Uid
       prefix, uniq = uid.split("_", 2)
       prefix == prefix_for_uid && uniq&.length == 15
     end
+  end
+
+  included do
+    before_validation :generate_uid, on: :create
+    validate :valid_uid, on: :create
+  end
+
+  private
+
+  def generate_uid
+    return if uid.present?
+
+    self.uid = unique_uid
+  end
+
+  def valid_uid
+    prefix, uniq = uid.split("_")
+    errors.add(:base, "invalid_id_prefix") if prefix != self.class.prefix_for_uid
+    errors.add(:base, "id_too_short") if uniq.length != 15
+  end
+
+  def unique_uid
+    uid = self.class.generate_uid
+    return uid unless self.class.exists?(uid: uid)
+
+    unique_uid
   end
 end

--- a/spec/models/concerns/sluggable_spec.rb
+++ b/spec/models/concerns/sluggable_spec.rb
@@ -40,14 +40,14 @@ RSpec.describe Sluggable do
   let(:dummy) { SluggableDummy.new(0, title: "aa bb") }
 
   it "sets the slug" do
-    expect(dummy.unique_slug).to eq("aa-bb")
+    expect(dummy.__send__(:unique_slug)).to eq("aa-bb")
   end
 
   context "when there are already instances with that slug" do
     let(:dummy) { SluggableDummy.new(3, title: "aa bb") }
 
     it "sets the slug" do
-      expect(dummy.unique_slug).to eq("aa-bb-4")
+      expect(dummy.__send__(:unique_slug)).to eq("aa-bb-4")
     end
   end
 end


### PR DESCRIPTION
### Description

Uid collision is extremely unlikely, but it can happen. No reason we shouldn't handle it. I took a book from `Sluggable` and reworked both concerns a bit, to better resemble each other.

Here's what I did in Sluggable:
- remove uniqueness validation - DB does that for us
- rename and privatize generation methods to be in line with Uids
- check for `exists` directly without needless `slug_taken` extraction

Uid:
- remove uniqueness validation - DB does that for us
- remove presence validation - we populate uid in before_validate so it's impossible to be valid. And also DB does that for us
- handle unlikely uid collision
- move the methods around to follow [Ruby Style Guide](https://rubystyle.guide/#consistent-classes) and other classes
- move instance methods outside `included do` since it's an anti-pattern

### Reviewer Checklist

- [x] PR has a clear title and description
- [ ] Manually tested the changes that the PR introduces
- [x] Changes introduced by the PR are covered by tests of acceptable quality
- [x] Checked the quality of [commit messages](http://chris.beams.io/posts/git-commit/)