### PR TITLE
Only prep call should go to default sales person for now

### DIFF
--- a/app/mailers/specialist_mailer.rb
+++ b/app/mailers/specialist_mailer.rb
@@ -25,7 +25,7 @@ class SpecialistMailer < ApplicationMailer
 
     @project = project
     @application = application
-    @sales_person = sales_person_for(project.user.company)
+    @sales_person = project.user.company.sales_person
     mail(
       from: @sales_person.email_with_name,
       to: @application.specialist.account.email,
@@ -37,7 +37,7 @@ class SpecialistMailer < ApplicationMailer
 
   def interview_reschedule_request(interview)
     @interview = interview
-    @sales_person = sales_person_for(interview.user.company)
+    @sales_person = interview.user.company.sales_person
     mail(
       from: @sales_person.email_with_name,
       to: interview.specialist.account.email,
@@ -49,7 +49,7 @@ class SpecialistMailer < ApplicationMailer
 
   def more_time_options_added(interview)
     @interview = interview
-    @sales_person = sales_person_for(interview.user.company)
+    @sales_person = interview.user.company.sales_person
     mail(
       from: @sales_person.email_with_name,
       to: interview.specialist.account.email,
@@ -61,7 +61,7 @@ class SpecialistMailer < ApplicationMailer
 
   def interview_reminder(interview)
     @interview = interview
-    @sales_person = sales_person_for(interview.user.company)
+    @sales_person = interview.user.company.sales_person
     mail(
       from: @sales_person.email_with_name,
       to: interview.specialist.account.email,
@@ -76,7 +76,7 @@ class SpecialistMailer < ApplicationMailer
     @interview = interview
     @user = interview.user
     @specialist = interview.specialist
-    @sales_person = sales_person_for(user.company)
+    @sales_person = default_sales_person_for(company)
     mail(
       from: @sales_person.email_with_name,
       to: @specialist.account.email,
@@ -89,7 +89,7 @@ class SpecialistMailer < ApplicationMailer
 
   def post_interview(interview)
     @interview = interview
-    @sales_person = sales_person_for(interview.user.company)
+    @sales_person = interview.user.company.sales_person
     @account = interview.specialist.account
     mail(
       from: "Advisable <hello@advisable.com>",
@@ -103,7 +103,7 @@ class SpecialistMailer < ApplicationMailer
 
   private
 
-  def sales_person_for(company)
+  def default_sales_person_for(company)
     SalesPerson.default_for_specialist || company.sales_person
   end
 end

--- a/app/mailers/user_mailer.rb
+++ b/app/mailers/user_mailer.rb
@@ -9,7 +9,7 @@ class UserMailer < ApplicationMailer
 
   def interview_reschedule_request(interview)
     @interview = interview
-    @sales_person = sales_person_for(interview.user.company)
+    @sales_person = interview.user.company.sales_person
     mail(from: @sales_person.email_with_name, to: interview.user.account.email, subject: "Interview Reschedule Request")
   end
 
@@ -72,7 +72,7 @@ class UserMailer < ApplicationMailer
 
   def need_more_time_options(interview)
     @interview = interview
-    @sales_person = sales_person_for(interview.user.company)
+    @sales_person = interview.user.company.sales_person
     mail(
       from: @sales_person.email_with_name,
       to: interview.user.account.email,
@@ -84,7 +84,7 @@ class UserMailer < ApplicationMailer
 
   def interview_reminder(interview)
     @interview = interview
-    @sales_person = sales_person_for(interview.user.company)
+    @sales_person = interview.user.company.sales_person
     mail(
       from: @sales_person.email_with_name,
       to: interview.user.account.email,
@@ -98,7 +98,7 @@ class UserMailer < ApplicationMailer
   def post_interview(interview)
     @interview = interview
     @account = interview.user.account
-    @sales_person = sales_person_for(interview.user.company)
+    @sales_person = interview.user.company.sales_person
 
     mail(
       from: "Advisable <hello@advisable.com>",
@@ -120,7 +120,7 @@ class UserMailer < ApplicationMailer
     end
   end
 
-  def sales_person_for(company)
+  def default_sales_person_for(company)
     SalesPerson.default_for_user || company.sales_person
   end
 end


### PR DESCRIPTION
### Description

Turns out changes in #1654 were a bit too eager. Since this will happen across more and more communication eventually I think it makes sense to keep the new "separation of communication system" around. But for now only use it for prep calls.

<img width="934" alt="CleanShot 2021-12-09 at 18 35 45" src="https://user-images.githubusercontent.com/986645/145534638-4af0c4a7-d846-49f8-99b2-816dd2b45744.png">

<img width="561" alt="CleanShot 2021-12-10 at 08 03 27" src="https://user-images.githubusercontent.com/986645/145534666-bdcde656-6f65-4325-b381-8557dcc8f00b.png">

<img width="1303" alt="CleanShot 2021-12-10 at 08 25 12" src="https://user-images.githubusercontent.com/986645/145534617-930c0d8e-7e2d-45fa-a1e7-dd6883065b15.png">

### Reviewer Checklist

- [ ] PR has a clear title and description
- [ ] Manually tested the changes that the PR introduces
- [ ] Changes introduced by the PR are covered by tests of acceptable quality
- [ ] Checked the quality of [commit messages](http://chris.beams.io/posts/git-commit/)