### PR TITLE
Handle cases when skill does not exist in test data

### DIFF
--- a/app/lib/new_test_data.rb
+++ b/app/lib/new_test_data.rb
@@ -109,7 +109,9 @@ class NewTestData
     categories = SkillCategory.upsert_all(categories_data, returning: %w[id name], unique_by: :slug).pluck("name", "id").to_h
 
     skill_category_skills_data = yml[:skill_categories].flat_map do |category, skills|
-      skills.map do |skill|
+      skills.filter_map do |skill|
+        next unless @skills[skill]
+
         {skill_id: @skills[skill], skill_category_id: categories[category], created_at: now, updated_at: now}
       end
     end


### PR DESCRIPTION
I refreshed the test data yml and it seems some skills have been removed. This prevents the test data crashing if a category skill does not exist.

### Reviewer Checklist

- [ ] PR has a clear title and description
- [ ] Manually tested the changes that the PR introduces
- [ ] Changes introduced by the PR are covered by tests of acceptable quality
- [ ] Checked the quality of [commit messages](http://chris.beams.io/posts/git-commit/)
