### PR TITLE
Fix copy to clipboard action for belongs to columns

### DIFF
--- a/app/javascript/toby/attributes/belongsTo.js
+++ b/app/javascript/toby/attributes/belongsTo.js
@@ -20,7 +20,7 @@ export default {
     return record[attribute.name]?.id || undefined;
   },
   copy: function (attribute, record) {
-    return record[attribute.name] || "";
+    return record[attribute.name]?._label || "";
   },
   input: function BelongsToAttributeInput({ resource, attribute, record }) {
     const schema = useSchema();


### PR DESCRIPTION
Previously when clicking the copy to clipboard button for a belongs to column in Toby it would copy "[Object object]" to the clipboard instead of the column value.