### PR TITLE
Set started_working_at when application goes to Working

### DIFF
--- a/app/graphql/mutations/start_working.rb
+++ b/app/graphql/mutations/start_working.rb
@@ -21,6 +21,7 @@ module Mutations
 
       application = Application.find_by!(uid: args[:application])
       application.status = "Working"
+      application.started_working_at = Time.zone.now
       application.project_type = args[:project_type]
       application.monthly_limit = args[:monthly_limit] if args[:project_type] == "Flexible"
       save_with_current_account!(application)

--- a/spec/graphql/mutations/start_working_spec.rb
+++ b/spec/graphql/mutations/start_working_spec.rb
@@ -26,10 +26,12 @@ RSpec.describe Mutations::StartWorking do
   end
 
   it "sets all the attributes" do
+    expect(application.started_working_at).to be_nil
     AdvisableSchema.execute(query, context:)
 
     application.reload
     expect(application.status).to eq("Working")
+    expect(application.started_working_at).not_to be_nil
     expect(application.project_type).to eq("Fixed")
   end
 


### PR DESCRIPTION
Resolves:
[Asana](https://app.asana.com/0/1200808264546087/1201721940067983)
[Slack discussion](https://advisable.slack.com/archives/C01ABN4GQG7/p1643203804003200?thread_ts=1643202576.001500&cid=C01ABN4GQG7)

### Description

Pretty much what it says on the tin.

Are there any other places where application status can change?

### Reviewer Checklist

- [ ] PR has a clear title and description
- [ ] Manually tested the changes that the PR introduces
- [ ] Changes introduced by the PR are covered by tests of acceptable quality
- [ ] Checked the quality of [commit messages](http://chris.beams.io/posts/git-commit/)