### PR TITLE
Set payment request status to paid from Stripe webhook

### DIFF
--- a/app/lib/stripe_events/payment_intent_succeeded.rb
+++ b/app/lib/stripe_events/payment_intent_succeeded.rb
@@ -37,6 +37,7 @@ module StripeEvents
     def process_payment
       payment = Payment.find_by!(uid: metadata.payment)
       payment.update(status: intent.status, charged_at: Time.zone.now)
+      payment.mark_paid!
       UpdateCompanysPaymentMethodJob.perform_later(payment.company, intent.payment_method)
     end
   end


### PR DESCRIPTION
Resolves: [Asana](https://app.asana.com/0/1200808264546087/1201762648875152/f)

### Description

Basically does what `if intent.status == "succeeded"` in `charge!` does.

### Reviewer Checklist

- [ ] PR has a clear title and description
- [ ] Manually tested the changes that the PR introduces
- [ ] Changes introduced by the PR are covered by tests of acceptable quality
- [ ] Checked the quality of [commit messages](http://chris.beams.io/posts/git-commit/)