### PR TITLE
Add CAPYBARA_BROWSER env var to change browser used in selenium tests

### DIFF
--- a/spec/support/capybara.rb
+++ b/spec/support/capybara.rb
@@ -15,10 +15,12 @@ RSpec.configure do |config|
       Webdrivers::Chromedriver.required_version = ENV["CHROMEDRIVER_VERSION"]
     end
 
+    browser = ENV["CAPYBARA_BROWSER"] || "chrome"
+
     if ENV["HEADLESS"] == "false"
-      driven_by :selenium, using: :chrome
+      driven_by :selenium, using: browser.to_sym
     else
-      driven_by :selenium, using: :headless_chrome
+      driven_by :selenium, using: "headless_#{browser}".to_sym
     end
   end
 


### PR DESCRIPTION
Adds "CAPYBARA_BROWSER" environment variable so that Tommy can use Firefox for system tests instead of chrome.

### Reviewer Checklist

- [ ] PR has a clear title and description
- [ ] Manually tested the changes that the PR introduces
- [ ] Changes introduced by the PR are covered by tests of acceptable quality
- [ ] Checked the quality of [commit messages](http://chris.beams.io/posts/git-commit/)