### PR TITLE
We no longer have a set_password path

### DIFF
--- a/app/helpers/mail_helper.rb
+++ b/app/helpers/mail_helper.rb
@@ -63,7 +63,7 @@ module MailHelper
   end
 
   def set_password_url
-    "#{app_host}/set_password"
+    app_host
   end
 
   def manage_subscriptions_url(account)

--- a/app/javascript/src/ApplicationRoutes.js
+++ b/app/javascript/src/ApplicationRoutes.js
@@ -52,6 +52,10 @@ const ApplicationRoutes = () => {
         <Switch>
           {isClient && <Redirect from="/" exact to="/explore" />}
 
+          <Route path="/set_password">
+            <Redirect to="/" />
+          </Route>
+
           <Route path="/" exact>
             <RequireAuthentication>
               <FreelancerDashboard />


### PR DESCRIPTION
This links new invites to "/", where the set password logic will kick in. And redirects any old links to /set_password to the root path instead.