### PR TITLE
Add support for InterviewRequest message types

### DIFF
--- a/app/javascript/src/apolloCache.js
+++ b/app/javascript/src/apolloCache.js
@@ -23,6 +23,8 @@ const createCache = () => {
         "GuildPostMessage",
         "ConsultationRequestMessage",
         "ConsultationDeclinedMessage",
+        "InterviewRequestMessage",
+        "InterviewDeclinedMessage",
         "InterviewScheduledMessage",
         "AgreementCreatedMessage",
         "AgreementAcceptedMessage",

--- a/app/javascript/src/components/Button/index.js
+++ b/app/javascript/src/components/Button/index.js
@@ -6,6 +6,7 @@ export const buttonStyles = composeStyles({
     flex
     relative
     items-center
+    justify-center
     rounded-full
     font-medium
   `,

--- a/app/javascript/src/views/Messages/components/InterviewRequestMessage.js
+++ b/app/javascript/src/views/Messages/components/InterviewRequestMessage.js
@@ -1,0 +1,199 @@
+import { ArrowLeft, Calendar } from "@styled-icons/heroicons-solid";
+import {
+  theme,
+  Modal,
+  useModal,
+  Textarea,
+  DialogDisclosure,
+} from "@advisable/donut";
+import React, { useEffect, useMemo, useState } from "react";
+import Button from "src/components/Button";
+import useViewer from "src/hooks/useViewer";
+import { BaseMessage } from "./Message";
+import { useMessagePrompt } from "./MessagePrompt";
+import CalendarIllustration from "src/illustrations/zest/calendar";
+import { Link, useLocation } from "react-router-dom";
+import CircularButton from "src/components/CircularButton";
+import { useDeclineInterview } from "../queries";
+
+function DeclineInterviewRequest({ message, onBack, onDecline }) {
+  const [decline, { loading }] = useDeclineInterview();
+  const [reason, setReason] = useState("");
+  const sender = message.author?.name;
+
+  const handleDecline = async () => {
+    await decline({
+      variables: {
+        input: {
+          interview: message.interview.id,
+          reason: reason.trim(),
+        },
+      },
+    });
+
+    onDecline();
+  };
+
+  return (
+    <>
+      <div className="absolute left-3 top-3">
+        <CircularButton onClick={onBack} icon={ArrowLeft} />
+      </div>
+      <h3 className="mb-2 text-center text-2xl font-semibold tracking-tight">
+        Decline call request
+      </h3>
+      <p className="text-center mb-6">
+        Let {sender} know why you are declining their request.
+      </p>
+      <Textarea
+        autoFocus
+        minRows={8}
+        name="reason"
+        value={reason}
+        marginBottom={8}
+        placeholder={`Message to ${sender}...`}
+        onChange={(e) => setReason(e.target.value)}
+      />
+      <Button
+        size="lg"
+        loading={loading}
+        className="w-full"
+        variant="secondary"
+        onClick={handleDecline}
+        disabled={reason.trim().length === 0}
+      >
+        Decline request
+      </Button>
+    </>
+  );
+}
+
+function AcceptInterviewRequest({ message, onDecline }) {
+  const location = useLocation();
+  const sender = message.author?.name;
+
+  return (
+    <div>
+      <CalendarIllustration
+        className="mx-auto mb-5"
+        width="160px"
+        color={theme.colors.blue100}
+      />
+      <div className="text-center mb-8">
+        <h4 className="text-xl font-semibold tracking-tight mb-1">
+          New call request
+        </h4>
+        <p className="text-lg leading-normal">
+          {sender} has requested a 30 minute call with you. After speaking with
+          them you will be able to send them a request to work together.
+        </p>
+      </div>
+      <div className="flex gap-3">
+        <Link
+          className="w-full"
+          to={{
+            state: { from: location.pathname },
+            pathname: `/interview_request/${message.interview.id}`,
+          }}
+        >
+          <Button size="lg" className="w-full">
+            View availability
+          </Button>
+        </Link>
+        <Button
+          size="lg"
+          className="w-full"
+          variant="outlined"
+          onClick={onDecline}
+        >
+          Decline
+        </Button>
+      </div>
+    </div>
+  );
+}
+
+function InterviewRequestModal({ message, modal }) {
+  const [decline, setDecline] = useState(false);
+
+  return (
+    <Modal modal={modal}>
+      {decline ? (
+        <DeclineInterviewRequest
+          message={message}
+          onBack={() => setDecline(false)}
+        />
+      ) : (
+        <AcceptInterviewRequest
+          message={message}
+          onDecline={() => setDecline(true)}
+        />
+      )}
+    </Modal>
+  );
+}
+
+function InterviewRequestForRecipient({ message }) {
+  const modal = useModal();
+  const sender = message.author?.name;
+  const { show, dismiss, highlight } = useMessagePrompt(
+    message,
+    "New call request",
+  );
+
+  const isPending = useMemo(() => {
+    return ["Call Requested", "Call Reminded"].includes(
+      message.interview.status,
+    );
+  }, [message]);
+
+  useEffect(() => {
+    if (isPending) {
+      show();
+    } else {
+      dismiss();
+    }
+  }, [show, dismiss, isPending]);
+
+  return (
+    <BaseMessage message={message} highlight={highlight}>
+      <div className="p-4 border-2 border-solid border-neutral100 rounded-lg flex">
+        <div className="shrink-0 w-10 h-10 bg-blue100 rounded-full grid place-items-center">
+          <Calendar className="w-5 h-5 text-blue800" />
+        </div>
+        <div className="flex-1 px-3">
+          <h5 className="font-medium leading-none text-lg mb-1">
+            {sender} requested a call with you
+          </h5>
+          <p className="text-neutral700">Check their availability</p>
+        </div>
+        {isPending && (
+          <DialogDisclosure {...modal}>
+            {(disclosure) => <Button {...disclosure}>Respond</Button>}
+          </DialogDisclosure>
+        )}
+        <InterviewRequestModal modal={modal} message={message} />
+      </div>
+    </BaseMessage>
+  );
+}
+
+function InterviewRequestForSender({ message }) {
+  return (
+    <BaseMessage message={message}>
+      <div className="p-4 border-2 border-solid border-neutral100 rounded-lg flex">
+        {message.author?.name} requested a call
+      </div>
+    </BaseMessage>
+  );
+}
+
+export default function InterviewRequestMessage({ message }) {
+  const viewer = useViewer();
+
+  if (viewer.id === message.interview?.specialist?.id) {
+    return <InterviewRequestForRecipient message={message} />;
+  }
+
+  return <InterviewRequestForSender message={message} />;
+}

--- a/app/javascript/src/views/Messages/components/Message.js
+++ b/app/javascript/src/views/Messages/components/Message.js
@@ -13,6 +13,8 @@ import ConsultationDeclinedMessage from "./SystemMessage/ConsultationDeclined";
 import AgreementCreatedMessage from "./AgreementCreatedMessage";
 import AgreementAcceptedMessage from "./SystemMessage/AgreementAcceptedMessage";
 import AgreementDeclinedMessage from "./SystemMessage/AgreementDeclinedMessage";
+import InterviewDeclinedMessage from "./SystemMessage/InterviewDeclinedMessage";
+import InterviewRequestMessage from "./InterviewRequestMessage";
 
 const COMPONENTS = {
   UserMessage,
@@ -24,6 +26,8 @@ const COMPONENTS = {
   AgreementCreatedMessage,
   AgreementAcceptedMessage,
   AgreementDeclinedMessage,
+  InterviewRequestMessage,
+  InterviewDeclinedMessage,
 };
 
 export default function Message({ message }) {

--- a/app/javascript/src/views/Messages/components/SystemMessage/InterviewDeclinedMessage.js
+++ b/app/javascript/src/views/Messages/components/SystemMessage/InterviewDeclinedMessage.js
@@ -1,0 +1,17 @@
+import React from "react";
+import possessive from "src/utilities/possesive";
+
+export default function ConsultationDeclinedMessage({ message }) {
+  const { user, specialist } = message.interview || {};
+
+  return (
+    <div
+      id={message.id}
+      data-status={message.status}
+      className="text-center p-4 rounded-xl border-2 border-solid border-neutral100"
+    >
+      {specialist?.firstName} declined {possessive(user?.firstName)} call
+      request
+    </div>
+  );
+}

--- a/app/javascript/src/views/Messages/queries/declineInterview.gql
+++ b/app/javascript/src/views/Messages/queries/declineInterview.gql
@@ -1,0 +1,8 @@
+mutation declineInterview($input: DeclineInterviewInput!) {
+  declineInterview(input: $input) {
+    interview {
+      id
+      status
+    }
+  }
+}

--- a/app/javascript/src/views/Messages/queries/index.js
+++ b/app/javascript/src/views/Messages/queries/index.js
@@ -16,6 +16,7 @@ import ACCEPT_CONSULTATION from "./acceptConsultation.gql";
 import DECLINE_CONSULTATION from "./declineConsultationRequest.gql";
 import SETUP_PAYMENTS_DATA from "./setupPaymentsData.gql";
 import UPDATE_INVOICE_SETTINGS from "./updateInvoiceSettings.gql";
+import DECLINE_INTERVIEW from "./declineInterview.gql";
 
 export function useConversations() {
   return useQuery(CONVERSATIONS);
@@ -166,4 +167,8 @@ export function useSetupPaymentsData(opts) {
 
 export function useUpdateInvoiceSettings() {
   return useMutation(UPDATE_INVOICE_SETTINGS);
+}
+
+export function useDeclineInterview() {
+  return useMutation(DECLINE_INTERVIEW);
 }

--- a/app/javascript/src/views/Messages/queries/messageFields.gql
+++ b/app/javascript/src/views/Messages/queries/messageFields.gql
@@ -47,6 +47,35 @@ fragment MessageFields on MessageInterface {
     }
   }
 
+  ... on InterviewRequestMessage {
+    interview {
+      id
+      status
+      specialist {
+        id
+      }
+    }
+    author {
+      id
+      name
+      avatar
+    }
+  }
+
+  ... on InterviewDeclinedMessage {
+    interview {
+      id
+      specialist {
+        id
+        firstName
+      }
+      user {
+        id
+        firstName
+      }
+    }
+  }
+
   ... on AgreementCreatedMessage {
     agreement {
       id


### PR DESCRIPTION
Resolves: [Ticket](https://app.asana.com/0/1200808264546087/1201877571536991)

### Description

This is part one of a few updates for the front-end to merge consultations and interviews after https://github.com/advisablecom/Advisable/pull/1755 was merged.

This adds support for `InterviewRequestMessage` message types. These aren't actually being created yet as we haven't switched over the consultation request to create them. I want to try to keep the PR's small while we move everything over.

### QA Testing
In order to test this, you will need to manually create an interview request message. The easiest way to go about this is by using an existing application record...

```rb
a = Application.first
interview = Interview.create(application: a, user: a.project.user, status: "Call Requested")
interview.user.update(availability: [2.days.from_now.beginning_of_hour])
conversation = Conversation.by_accounts(interview.specialist, interview.user)
conversation.new_message!(author: user.account, content:"This is the message", interview:, kind: "InterviewRequest")
```

### Reviewer Checklist

- [ ] PR has a clear title and description
- [ ] Manually tested the changes that the PR introduces
- [ ] Changes introduced by the PR are covered by tests of acceptable quality
- [ ] Checked the quality of [commit messages](http://chris.beams.io/posts/git-commit/)