### PR TITLE
Switch from using requestConsultation to requestInterview

### DIFF
--- a/app/javascript/src/components/ConnectButton/RequestConsultationMessage.js
+++ b/app/javascript/src/components/ConnectButton/RequestConsultationMessage.js
@@ -4,7 +4,7 @@ import { Form, Formik } from "formik";
 import React from "react";
 import FormField from "../FormField";
 import SubmitButton from "../SubmitButton";
-import { useRequestConsultation } from "./queries";
+import { useRequestInterview } from "./queries";
 import { object, string } from "yup";
 
 const validationSchema = object({
@@ -25,10 +25,10 @@ function ListItem({ children }) {
 }
 
 export default function RequestConsultationMessage({ specialist, onSubmit }) {
-  const [requestConsultation] = useRequestConsultation();
+  const [requestInterview] = useRequestInterview();
 
   const handleSubmit = async (values) => {
-    await requestConsultation({
+    await requestInterview({
       variables: {
         input: {
           specialist: specialist.id,
@@ -39,7 +39,7 @@ export default function RequestConsultationMessage({ specialist, onSubmit }) {
         cache.modify({
           id: cache.identify(specialist),
           fields: {
-            consultation: () => result.data.requestConsultation.consultation,
+            interview: () => result.data.requestInterview.interview,
           },
         });
       },

--- a/app/javascript/src/components/ConnectButton/queries/index.js
+++ b/app/javascript/src/components/ConnectButton/queries/index.js
@@ -2,7 +2,7 @@ import { useMutation, useQuery } from "@apollo/client";
 import AVAILABILITY from "./availability.gql";
 import UPDATE_AVAILABILITY from "./updateAvailability.gql";
 import CREATE_CONVERSATION from "./createConversation.gql";
-import REQUEST_CONSULTATION from "./requestConsultation.gql";
+import REQUEST_INTERVIEW from "./requestInterview.gql";
 import CREATE_CLIENT_ACCOUNT from "./createClientAccount.gql";
 import CREATE_FREELANCER_ACCOUNT from "./createFreelancerAccount.gql";
 
@@ -14,8 +14,8 @@ export function useUpdateAvailability() {
   return useMutation(UPDATE_AVAILABILITY);
 }
 
-export function useRequestConsultation() {
-  return useMutation(REQUEST_CONSULTATION);
+export function useRequestInterview() {
+  return useMutation(REQUEST_INTERVIEW);
 }
 
 export function useCreateClientAccount() {

--- a/app/javascript/src/components/ConnectButton/queries/requestConsultation.gql
+++ b/app/javascript/src/components/ConnectButton/queries/requestConsultation.gql
@@ -1,8 +1,0 @@
-mutation RequestConsultation($input: RequestConsultationInput!) {
-  requestConsultation(input: $input) {
-    consultation {
-      id
-      status
-    }
-  }
-}

--- a/app/javascript/src/components/ConnectButton/queries/requestInterview.gql
+++ b/app/javascript/src/components/ConnectButton/queries/requestInterview.gql
@@ -1,0 +1,8 @@
+mutation RequestInterview($input: RequestInterviewInput!) {
+  requestInterview(input: $input) {
+    interview {
+      id
+      status
+    }
+  }
+}

--- a/spec/system/request_consultation_spec.rb
+++ b/spec/system/request_consultation_spec.rb
@@ -6,6 +6,11 @@ RSpec.describe "Request consultation" do
   let(:freelancer) { create(:specialist) }
   let(:user) { create(:user) }
 
+  before do
+    allow_any_instance_of(Project).to receive(:sync_to_airtable)
+    create(:case_study_article, :with_skills, specialist: freelancer)
+  end
+
   def complete_request_consultation_flow
     monday = Date.parse("monday")
     delta = monday > Time.zone.now ? 0 : 7


### PR DESCRIPTION
Resolves: [Ticket](https://app.asana.com/0/1200808264546087/1201877571536991/f)

### Description

**NOTE**
Before releasing this we need to check there are no more zaps that are expecting consultation records to be created and to update them if there are. After this is merged no more consultation records with be created.

This updates the request consultation modal to use the new `requestInterview` mutation instead of `requestConsultation`. This is the last piece needed before we can continue to remove the rest of consultations from the app.

### Reviewer Checklist

- [ ] PR has a clear title and description
- [ ] Manually tested the changes that the PR introduces
- [ ] Changes introduced by the PR are covered by tests of acceptable quality
- [ ] Checked the quality of [commit messages](http://chris.beams.io/posts/git-commit/)