### PR TITLE
Add NODE_DEBUG environment variable

### DIFF
--- a/config/webpack/environment.js
+++ b/config/webpack/environment.js
@@ -18,6 +18,7 @@ const plugins = [
     INTERCOM_APP_ID: null,
     SENTRY_FRONTEND_DSN: null,
     SENTRY_ENVIRONMENT: null,
+    NODE_DEBUG: null,
   }),
 ];
 


### PR DESCRIPTION
Turns out Twilio video calls require this environment variable to be set.

### Reviewer Checklist

- [ ] PR has a clear title and description
- [ ] Manually tested the changes that the PR introduces
- [ ] Changes introduced by the PR are covered by tests of acceptable quality
- [ ] Checked the quality of [commit messages](http://chris.beams.io/posts/git-commit/)
