### PR TITLE
Fix bug preventing agreement modal from closing

### DIFF
--- a/app/javascript/src/views/Messages/components/AgreementCreatedMessage.js
+++ b/app/javascript/src/views/Messages/components/AgreementCreatedMessage.js
@@ -365,8 +365,8 @@ export default function AgreementCreatedMessage({ message }) {
             </Button>
           )}
         </DialogDisclosure>
-        <AgreementModal agreement={message.agreement} modal={modal} />
       </Box>
+      <AgreementModal agreement={message.agreement} modal={modal} />
     </BaseMessage>
   );
 }


### PR DESCRIPTION
Resolves: [Ticket](https://app.asana.com/0/1200808264546087/1201989007424896/f)

The entire agreement card had an on click event listener to open the modal and the modal was nested within that so clicking on the close button was always intercepted.

### Reviewer Checklist

- [ ] PR has a clear title and description
- [ ] Manually tested the changes that the PR introduces
- [ ] Changes introduced by the PR are covered by tests of acceptable quality
- [ ] Checked the quality of [commit messages](http://chris.beams.io/posts/git-commit/)
