### PR TITLE
We have a direct link between PaymentRequest and Agreement now

### DIFF
--- a/app/mailers/user_mailer.rb
+++ b/app/mailers/user_mailer.rb
@@ -172,7 +172,7 @@ class UserMailer < ApplicationMailer
 
   def payment_request(payment_request)
     @payment_request = payment_request
-    @agreement = Agreement.accepted.order(created_at: :desc).find_by(payment_request.slice(:specialist, :company))
+    @agreement = payment_request.agreement
     @user = @agreement.user
     @account = @user.account
 


### PR DESCRIPTION
### Description

Tiny one that I just noticed. Since #1801 we have Agreement and PaymentRequest linked so we can do this directly now.

I've also updated all the [existing PaymentRequests](https://app.advisable.com/toby/paymentrequests):
```
PaymentRequest.where(agreement_id: nil).each do |pr| 
  agreement = Agreement.accepted.order(created_at: :desc).find_by(pr.slice(:specialist, :company))
  pr.update(agreement:)
end
```

So they all have direct links now.

### Reviewer Checklist

- [ ] PR has a clear title and description
- [ ] Manually tested the changes that the PR introduces
- [ ] Changes introduced by the PR are covered by tests of acceptable quality
- [ ] Checked the quality of [commit messages](http://chris.beams.io/posts/git-commit/)