### PR TITLE
Do not send invoice when we already sent it

### DIFF
--- a/app/models/payment.rb
+++ b/app/models/payment.rb
@@ -64,7 +64,7 @@ class Payment < ApplicationRecord
   def charge!
     return self if paid? || !total.positive?
 
-    GeneratePaymentInvoiceJob.perform_later(self, notify: true) if payment_request.present?
+    GeneratePaymentInvoiceJob.perform_later(self, notify: true) if payment_request.present? && pdf_key.blank?
 
     if company.project_payment_method == "Bank Transfer"
       update!(payment_method: "Bank Transfer")


### PR DESCRIPTION
Resolves: [Sofia's slack message](https://advisable.slack.com/archives/C015G61U30S/p1648478963139799?thread_ts=1648478558.287339&cid=C015G61U30S)

### Description

If we w have the pdf key, it means we generated invoice before. So we shouldn't do it again.

### Reviewer Checklist

- [ ] PR has a clear title and description
- [ ] Manually tested the changes that the PR introduces
- [ ] Changes introduced by the PR are covered by tests of acceptable quality
- [ ] Checked the quality of [commit messages](http://chris.beams.io/posts/git-commit/)