### PR TITLE
Stripe payment errors should be treated as info, not error

### DIFF
--- a/app/models/payment.rb
+++ b/app/models/payment.rb
@@ -89,7 +89,7 @@ class Payment < ApplicationRecord
     self
   rescue Stripe::StripeError => e
     update!(status: "failed", payment_intent_id: e.json_body.dig(:error, :payment_intent, :id))
-    Sentry.capture_exception(e, extra: {stripe_error: e.json_body[:error]})
+    Sentry.capture_exception(e, extra: {stripe_error: e.json_body[:error]}, level: "info")
     text = [
       "Something went wrong with the payment for *#{company&.name}* (#{company_id}) with *#{specialist&.account&.name}* (#{specialist&.uid})!",
       "Payment: #{uid}",


### PR DESCRIPTION
### Description

These sentry errors often scare me, but they're almost always about card declined or something like that. So they should be treated as info, not error.

### Reviewer Checklist

- [ ] PR has a clear title and description
- [ ] Manually tested the changes that the PR introduces
- [ ] Changes introduced by the PR are covered by tests of acceptable quality
- [ ] Checked the quality of [commit messages](http://chris.beams.io/posts/git-commit/)