### PR TITLE
Payment requests submission

### DIFF
--- a/app/javascript/src/views/PaymentRequests/NewPaymentRequest.js
+++ b/app/javascript/src/views/PaymentRequests/NewPaymentRequest.js
@@ -1,6 +1,13 @@
 import { object, string, number, array } from "yup";
-import { Field, Form, Formik, useField } from "formik";
-import { Textarea, Combobox, Input } from "@advisable/donut";
+import { Field, Form, Formik, useField, useFormikContext } from "formik";
+import {
+  Textarea,
+  Combobox,
+  Input,
+  Modal,
+  useModal,
+  DialogDisclosure,
+} from "@advisable/donut";
 import React from "react";
 import Button from "src/components/Button";
 import FormField from "src/components/FormField";
@@ -14,6 +21,7 @@ import useViewer from "src/hooks/useViewer";
 import BackButton from "src/components/BackButton";
 import NoActiveAgreements from "./NoActiveAgreements";
 import { Loading } from "src/components";
+import currency from "src/utilities/currency";
 
 const lineItemSchema = object().shape({
   description: string().required("Please provide a description"),
@@ -112,7 +120,33 @@ function PaymentRequestLineItems() {
   );
 }
 
+function ConfirmPaymentRequest({ modal, amount }) {
+  const { values, submitForm, isSubmitting } = useFormikContext();
+
+  return (
+    <Modal modal={modal} className="p-5">
+      <h3 className="text-xl font-semibold mb-1">
+        Request {currency(amount, { format: "$0,0.00" })} from{" "}
+        {values.agreement?.name}?
+      </h3>
+      <p className="mb-6">
+        Are you sure you want to send this payment request. Payment requests
+        can’t be edited after they’re sent.
+      </p>
+      <div className="flex gap-2">
+        <Button size="lg" onClick={submitForm} loading={isSubmitting}>
+          Send request
+        </Button>
+        <Button size="lg" type="hide" variant="outlined" onClick={modal.hide}>
+          Cancel
+        </Button>
+      </div>
+    </Modal>
+  );
+}
+
 export default function NewPaymentRequest() {
+  const modal = useModal();
   const navigate = useNavigate();
   const viewer = useViewer();
   const [send] = useCreatePaymentRequest();
@@ -175,6 +209,10 @@ export default function NewPaymentRequest() {
     >
       {(formik) => (
         <Form>
+          <ConfirmPaymentRequest
+            modal={modal}
+            amount={calculateTotal(formik)}
+          />
           <div className="mb-5">
             <BackButton to="/payment_requests" />
           </div>
@@ -212,13 +250,17 @@ export default function NewPaymentRequest() {
                     placeholder="Memo"
                   />
 
-                  <Button
-                    size="lg"
-                    loading={formik.isSubmitting}
-                    disabled={!formik.isValid}
-                  >
-                    Send request
-                  </Button>
+                  <DialogDisclosure {...modal}>
+                    {(disclosure) => (
+                      <Button
+                        size="lg"
+                        disabled={!formik.isValid}
+                        {...disclosure}
+                      >
+                        Send request
+                      </Button>
+                    )}
+                  </DialogDisclosure>
                 </>
               ) : (
                 <NoActiveAgreements />

--- a/spec/system/payment_requests_spec.rb
+++ b/spec/system/payment_requests_spec.rb
@@ -47,6 +47,9 @@ RSpec.describe "Payment requests", type: :system do
     fill_in("lineItems[1].amount", with: "500")
     fill_in("memo", with: "This is a memo")
     click_button("Send request")
+    within("*[data-dialog]") do
+      click_button("Send request")
+    end
     expect(page).to have_content("This request is awaiting payment")
   end
 


### PR DESCRIPTION
- Adds confirmation modal when sending a payment request.
- Prevents sending payment request when return key is pressed in line items fields.

### Reviewer Checklist

- [ ] PR has a clear title and description
- [ ] Manually tested the changes that the PR introduces
- [ ] Changes introduced by the PR are covered by tests of acceptable quality
- [ ] Checked the quality of [commit messages](http://chris.beams.io/posts/git-commit/)

<img width="1247" alt="image" src="https://user-images.githubusercontent.com/1512593/160560139-fc1520db-ae9f-4031-8bf4-c54719b9bdc1.png">
