### PR TITLE
Prevent toby filters crashing on page transition

### DIFF
--- a/app/javascript/toby/views/resource/Filters/Filter.js
+++ b/app/javascript/toby/views/resource/Filters/Filter.js
@@ -35,11 +35,13 @@ function FilterType({ filter, resource, onChange }) {
 
   const handleChange = useCallback(
     (e) => {
-      const filter = attribute.filters.find((f) => f.name === e.target.value);
+      const filter = attribute?.filters.find((f) => f.name === e.target.value);
       onChange(filter);
     },
     [attribute, onChange],
   );
+
+  if (!attribute) return null;
 
   return (
     <Select size="s" value={filter.type} onChange={handleChange}>

--- a/app/javascript/toby/views/resource/Filters/filters/index.js
+++ b/app/javascript/toby/views/resource/Filters/filters/index.js
@@ -23,6 +23,8 @@ export function getValueComponentForFilter(resource, filter) {
   const attribute = resource.attributes.find(
     (f) => f.name === filter.attribute,
   );
+  if (!attribute) return null;
+
   const attributeFilter = attribute.filters.find((f) => f.name === filter.type);
   return FILTERS[attributeFilter.type];
 }
@@ -31,8 +33,11 @@ export default function Filter({ resource, filter, onChange }) {
   const attribute = resource.attributes.find(
     (f) => f.name === filter.attribute,
   );
+
+  if (!attribute) return null;
+
   const attributeFilter = attribute.filters.find((f) => f.name === filter.type);
-  let Component = FILTERS[attributeFilter.type];
+  let Component = FILTERS[attributeFilter?.type];
 
   if (!Component) {
     console.error("No filter handler found.", filter);


### PR DESCRIPTION
Spotted a small issue when using filters inside of Toby. When you have added a filter and you switch to another resource view, the page crashes because the filters are no longer relevant to that resource. They will get reset once the view transitions but we need to handle the cases when the filter attributes might be nil until the page changes.

![CleanShot 2022-04-08 at 08 18 30](https://user-images.githubusercontent.com/1512593/162384512-aa0b98ea-73d7-4ce3-9148-dabbef66b2cd.gif)

