### PR TITLE
Migrate existing shortlists to interests

### DIFF
--- a/app/models/case_study/interest.rb
+++ b/app/models/case_study/interest.rb
@@ -13,6 +13,7 @@ module CaseStudy
     has_many :interest_articles, dependent: :destroy
     has_many :articles, through: :interest_articles
 
+    validates :term, presence: true
     validates :term, uniqueness: {case_sensitive: false, scope: :account_id}
 
     def find_articles!

--- a/lib/tasks/data.rake
+++ b/lib/tasks/data.rake
@@ -11,4 +11,49 @@ namespace :data do
   task create_file: :environment do
     ProductionData.new.create_file!
   end
+
+  task migrate_cs_searches: :environment do
+    progressbar = ProgressBar.create(format: "Migrating searches: %a %b\u{15E7}%i %p%% %e", progress_mark: " ", remainder_mark: "\u{FF65}", total: CaseStudy::Search.count)
+
+    CaseStudy::Search.includes(skills: :skill).includes(:user).find_each do |search|
+      progressbar.increment
+
+      ActiveRecord::Base.transaction do
+        interest = interest_from_search(search)
+        next unless interest
+
+        copy_search_results(search, interest)
+        add_relevant_articles(search, interest)
+      end
+    end
+  end
+end
+
+def interest_from_search(search)
+  interest = CaseStudy::Interest.new(account_id: search.user.account_id)
+  goals = Array(search.goals).to_sentence
+  skills = search.skills.map(&:skill).map(&:name).to_sentence
+  interest.term = [goals, skills].filter_map(&:presence).join(" with ")
+  return unless interest.valid?
+
+  interest.term_vector
+  interest.save!
+  interest
+end
+
+def copy_search_results(search, interest)
+  treshold = 1.0
+  CaseStudy::Article.where(id: search.result_ids).find_each do |article|
+    similarity = article.embedding.cosine_similarity_with(interest.term_vector)
+    treshold = similarity if similarity < treshold
+    interest.interest_articles.create!(article:, similarity:)
+  end
+  interest.update!(treshold:)
+end
+
+def add_relevant_articles(search, interest)
+  articles = interest.articles_by_relevancy.
+    select { |a| a[:similarity] >= interest.treshold }.
+    reject { |a| search.result_ids.include?(a[:article_id]) }
+  interest.interest_articles.insert_all!(articles)
 end


### PR DESCRIPTION
Resolves: [Asana](https://app.asana.com/0/1200808264546087/1202106920148590/f)

### Description

- [x] For every case study search we want to create an interest record where the term is set to a comma separated list of the searches skills.
- [x] Any results on the case study search should be copied over to the interest.
- [x] Finally each new interest should check for any new results and add them if there are.

Pretty much done this as in the ticket, only the term I "improved" a bit with mashing up goals and skills. I think that'll give more relevant term, with what I've gathered from production searches.

This is built on top of https://github.com/advisablecom/Advisable/pull/1850 because of naming changes.

### Reviewer Checklist

- [ ] PR has a clear title and description
- [ ] Manually tested the changes that the PR introduces
- [ ] Changes introduced by the PR are covered by tests of acceptable quality
- [ ] Checked the quality of [commit messages](http://chris.beams.io/posts/git-commit/)