### PR TITLE
Prevent client signup from removing query params

### DIFF
--- a/app/javascript/src/views/ClientJoin/index.js
+++ b/app/javascript/src/views/ClientJoin/index.js
@@ -14,12 +14,15 @@ function ClientJoin() {
   const { routes, currentStepIndex, forwards } = useSteps(steps, {
     basePath: "/clients/join",
   });
+
+  const viewer = useViewer();
   const location = useLocation();
   const largeScreen = useBreakpoint("xlUp");
-  const viewer = useViewer();
-
+  // Because the user creates an account and then sets the password we create
+  // a 'signup' state inside of the router state to prevent redirecting until
+  // they have completed the signup flow.
   if (!viewer && !location.state?.signup) {
-    return <Navigate to={location.pathname} state={{ signup: true }} replace />;
+    return <Navigate to={location} state={{ signup: true }} replace />;
   }
 
   // Redirect to root if already logged in and not part of signup flow


### PR DESCRIPTION
Resolves: [Ticket](https://app.asana.com/0/1200808264546087/1202152968459562/f)

### Description

When a user lands on /clients/join we do a redirect to the same path but store a 'signup' param in the location state. We use this to determine if the user should be redirected away from the signup if they already have an account. This was clearing out any query params that were passed from users coming from the website. This PR updates that redirect to maintain any query params.

### Reviewer Checklist

- [ ] PR has a clear title and description
- [ ] Manually tested the changes that the PR introduces
- [ ] Changes introduced by the PR are covered by tests of acceptable quality
- [ ] Checked the quality of [commit messages](http://chris.beams.io/posts/git-commit/)
