### PR TITLE
Handle cases when resolved is nil

### DIFF
--- a/app/javascript/src/views/Feed/components/BottomBar.js
+++ b/app/javascript/src/views/Feed/components/BottomBar.js
@@ -53,7 +53,7 @@ const labelClasses = composeStyles({
 
 function BottomBarItem({ to, icon, children }) {
   const resolved = useResolvedPath(to);
-  const match = useMatch({ path: resolved.pathname, end: true });
+  const match = useMatch({ path: resolved?.pathname, end: true });
 
   return (
     <Link to={to} className={itemClasses({ active: match })}>

--- a/app/javascript/src/views/Feed/components/FeedSidebar.js
+++ b/app/javascript/src/views/Feed/components/FeedSidebar.js
@@ -52,7 +52,7 @@ const iconClasses = composeStyles({
 
 function SidebarItem({ to, icon, children }) {
   const resolved = useResolvedPath(to);
-  const match = useMatch({ path: resolved.pathname, end: true });
+  const match = useMatch({ path: resolved?.pathname, end: true });
 
   const handleClick = () => {
     window.scrollTo(0, 0);

--- a/app/javascript/src/views/UserOnboarding/index.js
+++ b/app/javascript/src/views/UserOnboarding/index.js
@@ -50,7 +50,7 @@ export default function UserOnboarding() {
   const matchingStepIndex = useMemo(() => {
     return STEPS.findIndex((step) => {
       const resolved = resolvePath(step.path, "/setup");
-      return matchPath(resolved.pathname, location.pathname);
+      return matchPath(resolved?.pathname, location.pathname);
     });
   }, [location]);
 


### PR DESCRIPTION
Resolves: [Ticket](https://sentry.io/organizations/advisable/issues/3263902013/?project=2019647&query=is%3Aunresolved)

### Description

Didn't know that `resolved` could be nil here. Maybe we should move to typescript to prevent this kind of thing. 🤣 

### Reviewer Checklist

- [ ] PR has a clear title and description
- [ ] Manually tested the changes that the PR introduces
- [ ] Changes introduced by the PR are covered by tests of acceptable quality
- [ ] Checked the quality of [commit messages](http://chris.beams.io/posts/git-commit/)
