### PR TITLE
Fix ImageGallery overlap

### DIFF
--- a/app/javascript/src/components/ImageGallery/index.js
+++ b/app/javascript/src/components/ImageGallery/index.js
@@ -41,7 +41,7 @@ const StyledViewableImageDialog = styled(Dialog).withConfig({
   left: 0;
   right: 0;
   bottom: 0;
-  z-index: 10;
+  z-index: 30;
   display: flex;
   position: fixed;
   align-items: center;


### PR DESCRIPTION
Resolves: [Ticket](https://app.asana.com/0/1200808264546087/1202272989176423/f)

### Description

I increased `z-index` of ImageGallery, so the Header won't overlap it
<img width="1106" alt="image" src="https://user-images.githubusercontent.com/849247/168426074-3612710a-4b9c-42c0-acd7-59b3486fdd2c.png">
