### PR TITLE
Add 'replace' to uses of Navigate component

### DIFF
--- a/app/javascript/src/ApplicationRoutes.js
+++ b/app/javascript/src/ApplicationRoutes.js
@@ -31,7 +31,7 @@ const PaymentRequests = lazy(() => import("./views/PaymentRequests"));
 
 function RedirectToFreelancerProfile() {
   const viewer = useViewer();
-  return <Navigate to={viewer.profilePath} />;
+  return <Navigate replace to={viewer.profilePath} />;
 }
 
 const ApplicationRoutes = () => {
@@ -48,11 +48,11 @@ const ApplicationRoutes = () => {
               <Route
                 path="/"
                 exact
-                element={<Navigate exact to="/explore" />}
+                element={<Navigate replace exact to="/explore" />}
               />
             )}
 
-            <Route path="/set_password" element={<Navigate to="/" />} />
+            <Route path="/set_password" element={<Navigate replace to="/" />} />
 
             <Route
               path="/"

--- a/app/javascript/src/components/RequireAuthentication/index.js
+++ b/app/javascript/src/components/RequireAuthentication/index.js
@@ -6,18 +6,18 @@ const SetPassword = lazy(() => import("src/views/SetPassword"));
 function RedirectToLogin() {
   const location = useLocation();
 
-  return <Navigate to="/login" state={{ from: location }} />;
+  return <Navigate replace to="/login" state={{ from: location }} />;
 }
 
 function RequireAuthentication({ children, specialistOnly, clientOnly }) {
   const viewer = useViewer();
 
   if (specialistOnly && viewer && !viewer.isSpecialist) {
-    return <Navigate to="/" />;
+    return <Navigate replace to="/" />;
   }
 
   if (clientOnly && viewer && !viewer.isClient) {
-    return <Navigate to="/" />;
+    return <Navigate replace to="/" />;
   }
 
   if (viewer?.needsToSetAPassword) {

--- a/app/javascript/src/views/CaseStudyReview/views/ReviewComment.js
+++ b/app/javascript/src/views/CaseStudyReview/views/ReviewComment.js
@@ -58,7 +58,10 @@ function ReviewComment({ data }) {
   }
   if (!oauthViewer) {
     return (
-      <Navigate to={`/review/${specialist.id}/case_studies/${article_id}`} />
+      <Navigate
+        replace
+        to={`/review/${specialist.id}/case_studies/${article_id}`}
+      />
     );
   }
 

--- a/app/javascript/src/views/CaseStudyReview/views/ReviewComplete.js
+++ b/app/javascript/src/views/CaseStudyReview/views/ReviewComplete.js
@@ -19,7 +19,10 @@ export default function ReviewComplete({ data }) {
 
   if (!oauthViewer) {
     return (
-      <Navigate to={`/review/${specialist.id}/case_studies/${article_id}`} />
+      <Navigate
+        replace
+        to={`/review/${specialist.id}/case_studies/${article_id}`}
+      />
     );
   }
 

--- a/app/javascript/src/views/CaseStudyReview/views/ReviewIntro.js
+++ b/app/javascript/src/views/CaseStudyReview/views/ReviewIntro.js
@@ -15,7 +15,12 @@ export default function ReviewIntro({ data }) {
     return <Reviewed />;
   }
   if (data.oauthViewer) {
-    return <Navigate to={`/review/${id}/case_studies/${article_id}/ratings`} />;
+    return (
+      <Navigate
+        replace
+        to={`/review/${id}/case_studies/${article_id}/ratings`}
+      />
+    );
   }
 
   return (

--- a/app/javascript/src/views/CaseStudyReview/views/ReviewRatings.js
+++ b/app/javascript/src/views/CaseStudyReview/views/ReviewRatings.js
@@ -76,7 +76,10 @@ function ReviewRatings({ data }) {
   }
   if (!oauthViewer) {
     return (
-      <Navigate to={`/review/${specialist.id}/case_studies/${article_id}`} />
+      <Navigate
+        replace
+        to={`/review/${specialist.id}/case_studies/${article_id}`}
+      />
     );
   }
 

--- a/app/javascript/src/views/ConfirmAccount/index.js
+++ b/app/javascript/src/views/ConfirmAccount/index.js
@@ -44,7 +44,7 @@ const ConfirmAccount = () => {
   }, [confirmAccount]);
 
   if (!parsed.email) {
-    return <Navigate to="/" />;
+    return <Navigate replace to="/" />;
   }
 
   return <Loading />;

--- a/app/javascript/src/views/Feed/index.js
+++ b/app/javascript/src/views/Feed/index.js
@@ -26,7 +26,7 @@ export default function Feed() {
   const onboarding = useTutorial("onboarding");
 
   if (!onboarding.isComplete) {
-    return <Navigate to="/setup/company" />;
+    return <Navigate replace to="/setup/company" />;
   }
 
   return (

--- a/app/javascript/src/views/Interview/CallRequested.js
+++ b/app/javascript/src/views/Interview/CallRequested.js
@@ -11,7 +11,7 @@ export default function CallRequested({ interview }) {
   const { isSpecialist } = useViewer();
 
   if (isSpecialist) {
-    return <Navigate to={`/interview_request/${id}`} />;
+    return <Navigate replace to={`/interview_request/${id}`} />;
   }
 
   return (

--- a/app/javascript/src/views/Interview/ClientRequestedReschedule.js
+++ b/app/javascript/src/views/Interview/ClientRequestedReschedule.js
@@ -10,7 +10,7 @@ export default function ClientRequestedReschedule({ interview }) {
   const { isSpecialist } = useViewer();
 
   if (isSpecialist) {
-    return <Navigate to={`/interview_request/${id}`} />;
+    return <Navigate replace to={`/interview_request/${id}`} />;
   }
 
   return (

--- a/app/javascript/src/views/Interview/MoreTimeOptionsAdded.js
+++ b/app/javascript/src/views/Interview/MoreTimeOptionsAdded.js
@@ -8,7 +8,7 @@ export default function MoreTimeOptionsAdded({ interview }) {
   const isSpecialist = viewer.isSpecialist;
 
   return isSpecialist ? (
-    <Navigate to={`/interview_request/${interview.id}`} />
+    <Navigate replace to={`/interview_request/${interview.id}`} />
   ) : (
     <CallRequested interview={interview} />
   );

--- a/app/javascript/src/views/Interview/RescheduleInterview.js
+++ b/app/javascript/src/views/Interview/RescheduleInterview.js
@@ -11,7 +11,7 @@ export default function RescheduleInterview({ interview }) {
   const isSpecialist = viewer.isSpecialist;
 
   if (!ALLOWED_STATUSES.includes(interview.status)) {
-    return <Navigate to={`/interviews/${interview.id}`} />;
+    return <Navigate replace to={`/interviews/${interview.id}`} />;
   }
 
   return isSpecialist ? (

--- a/app/javascript/src/views/InterviewRequest/InterviewRequest.js
+++ b/app/javascript/src/views/InterviewRequest/InterviewRequest.js
@@ -66,7 +66,9 @@ export default function InterviewRequestView() {
           />
           <Route
             path="*"
-            element={<Navigate to={`/interview_request/${interview.id}`} />}
+            element={
+              <Navigate replace to={`/interview_request/${interview.id}`} />
+            }
           />
         </Routes>
       )}

--- a/app/javascript/src/views/Messages/index.js
+++ b/app/javascript/src/views/Messages/index.js
@@ -44,7 +44,7 @@ export default function Messages() {
             />
           )}
           {hasConversations && isDesktop && (
-            <Route path="*" element={<Navigate to={ordered[0].id} />} />
+            <Route path="*" element={<Navigate replace to={ordered[0].id} />} />
           )}
           {!loading && isDesktop && (
             <Route path="*" element={<NoConversations />} />

--- a/app/javascript/src/views/NewAgreement/ConfirmAgreement.js
+++ b/app/javascript/src/views/NewAgreement/ConfirmAgreement.js
@@ -59,7 +59,7 @@ export default function ConfirmAgreement({ user }) {
   const { uploading } = attachmentProps;
 
   if (!location.state?.invoicing) {
-    return <Navigate to={`/new_agreement/${userId}/invoicing`} />;
+    return <Navigate replace to={`/new_agreement/${userId}/invoicing`} />;
   }
 
   const handleSubmit = async (values) => {

--- a/app/javascript/src/views/NewAgreement/InvoicingType.js
+++ b/app/javascript/src/views/NewAgreement/InvoicingType.js
@@ -44,7 +44,7 @@ export default function InvoicingType({ user }) {
   const companyName = user.company.name;
 
   if (!location.state?.collaboration) {
-    return <Navigate to={`/new_agreement/${userId}/collaboration`} />;
+    return <Navigate replace to={`/new_agreement/${userId}/collaboration`} />;
   }
 
   const handleSubmit = (values) => {

--- a/app/javascript/src/views/NewAgreement/index.js
+++ b/app/javascript/src/views/NewAgreement/index.js
@@ -26,7 +26,7 @@ export default function NewAgreement() {
         <Route path="confirm" element={<ConfirmAgreement {...data} />} />
         <Route
           path="*"
-          element={<Navigate to={`/new_agreement/${userId}`} />}
+          element={<Navigate replace to={`/new_agreement/${userId}`} />}
         />
       </Routes>
     </Container>

--- a/app/javascript/src/views/SetPassword/index.js
+++ b/app/javascript/src/views/SetPassword/index.js
@@ -28,7 +28,7 @@ export default function SetPassword() {
   };
 
   if (!viewer.needsToSetAPassword) {
-    return <Navigate to={from} />;
+    return <Navigate replace to={from} />;
   }
 
   const initialValues = {

--- a/app/javascript/src/views/Settings/ClientSettings/Invoices/index.js
+++ b/app/javascript/src/views/Settings/ClientSettings/Invoices/index.js
@@ -8,7 +8,7 @@ export default function Invoices() {
     <Routes>
       <Route path="/:id" element={<Invoice />} />
       <Route path="/" element={<InvoicesList />} />
-      <Route path="*" element={<Navigate to="/settings/invoices" />} />
+      <Route path="*" element={<Navigate replace to="/settings/invoices" />} />
     </Routes>
   );
 }

--- a/app/javascript/src/views/Settings/ClientSettings/PaymentSettings/index.js
+++ b/app/javascript/src/views/Settings/ClientSettings/PaymentSettings/index.js
@@ -20,7 +20,7 @@ const PaymentSettings = () => {
   const [updateInvoiceSettings] = useMutation(UPDATE_INVOICE_SETTINGS);
 
   if (!viewer.isTeamManager) {
-    return <Navigate to="/settings" />;
+    return <Navigate replace to="/settings" />;
   }
 
   const handleSubmit = async (values, formik) => {

--- a/app/javascript/src/views/Settings/ClientSettings/StripeInvoices/index.js
+++ b/app/javascript/src/views/Settings/ClientSettings/StripeInvoices/index.js
@@ -29,7 +29,7 @@ function Invoices() {
   const { loading, error, data, client } = useInvoices();
 
   if (!viewer.isTeamManager) {
-    return <Navigate to="/settings" />;
+    return <Navigate replace to="/settings" />;
   }
 
   if (loading) return <Loading />;

--- a/app/javascript/src/views/Settings/ClientSettings/Team/index.js
+++ b/app/javascript/src/views/Settings/ClientSettings/Team/index.js
@@ -9,7 +9,7 @@ export default function Team() {
   const viewer = useViewer();
 
   if (!viewer.isTeamManager) {
-    return <Navigate to="/settings" />;
+    return <Navigate replace to="/settings" />;
   }
 
   return (

--- a/app/javascript/src/views/Settings/ClientSettings/index.js
+++ b/app/javascript/src/views/Settings/ClientSettings/index.js
@@ -49,7 +49,7 @@ const ClientSettings = () => {
               <Route
                 exact
                 path="/"
-                element={<Navigate to="/settings/account" />}
+                element={<Navigate replace to="/settings/account" />}
               />
             )}
           </Routes>

--- a/app/javascript/src/views/Settings/SpecialistSettings/index.js
+++ b/app/javascript/src/views/Settings/SpecialistSettings/index.js
@@ -45,7 +45,10 @@ function SpecialistSettings() {
             {/* If the user is not on a small screen, then redirect them to the
           first settings page when they are on exactly /settings */}
             {breakpointS && (
-              <Route path="*" element={<Navigate to="/settings/general" />} />
+              <Route
+                path="*"
+                element={<Navigate replace to="/settings/general" />}
+              />
             )}
           </Routes>
         </Container>

--- a/app/javascript/src/views/Signup/index.js
+++ b/app/javascript/src/views/Signup/index.js
@@ -31,7 +31,7 @@ const Signup = () => {
   const notice = location?.state?.notice;
 
   if (viewer) {
-    return <Navigate to="/" />;
+    return <Navigate replace to="/" />;
   }
 
   const handleSubmit = async (values, formikBag) => {


### PR DESCRIPTION
I noticed that when we migrated to react-router 6 I didn't migrate the redirect components correctly. These should replace the browser state rather than adding to history stack.

### Reviewer Checklist

- [ ] PR has a clear title and description
- [ ] Manually tested the changes that the PR introduces
- [ ] Changes introduced by the PR are covered by tests of acceptable quality
- [ ] Checked the quality of [commit messages](http://chris.beams.io/posts/git-commit/)