### PR TITLE
Fix endless scroll in Toby

### DIFF
--- a/app/javascript/toby/App.js
+++ b/app/javascript/toby/App.js
@@ -2,26 +2,33 @@ import React from "react";
 import { ApolloProvider } from "@apollo/client";
 import { BrowserRouter as Router } from "react-router-dom";
 import { Provider as DonutProvider } from "@advisable/donut";
-import client from "./apolloClient";
+import createClient from "./apolloClient";
 import Routes from "./Routes";
 import { NotificationsProvider } from "src/components/Notifications";
 import { BaseStyles } from "./styles";
-import TobyProvider from "./components/TobyProvider";
+import TobyProvider, { useToby } from "./components/TobyProvider";
+
+function Apollo({ children }) {
+  const { resources } = useToby();
+  const client = createClient(resources);
+
+  return <ApolloProvider client={client}>{children}</ApolloProvider>;
+}
 
 const Root = () => {
   return (
-    <ApolloProvider client={client}>
-      <Router basename="/toby">
-        <NotificationsProvider>
-          <DonutProvider>
-            <BaseStyles />
-            <TobyProvider>
+    <TobyProvider>
+      <Apollo>
+        <Router basename="/toby">
+          <NotificationsProvider>
+            <DonutProvider>
+              <BaseStyles />
               <Routes />
-            </TobyProvider>
-          </DonutProvider>
-        </NotificationsProvider>
-      </Router>
-    </ApolloProvider>
+            </DonutProvider>
+          </NotificationsProvider>
+        </Router>
+      </Apollo>
+    </TobyProvider>
   );
 };
 

--- a/app/javascript/toby/apolloClient.js
+++ b/app/javascript/toby/apolloClient.js
@@ -1,61 +1,70 @@
 import { ApolloClient, createHttpLink } from "@apollo/client";
 import { setContext } from "@apollo/client/link/context";
 import { gql, InMemoryCache } from "@apollo/client";
+import { relayStylePagination } from "@apollo/client/utilities";
 
-const createCache = () => {
-  return new InMemoryCache({
-    possibleTypes: {},
-    typePolicies: {
-      Query: {
-        fields: {
-          views: {
-            merge(existing, incoming) {
-              return incoming;
-            },
+export default function createClient(resources = []) {
+  const typePolicies = {
+    Query: {
+      fields: {
+        views: {
+          merge(existing, incoming) {
+            return incoming;
           },
         },
       },
     },
-  });
-};
-
-const authLink = setContext((_, { headers }) => {
-  const csrfElement = document.querySelector("meta[name=csrf-token]");
-  const csrf = csrfElement?.getAttribute("content");
-
-  return {
-    headers: {
-      ...headers,
-      "X-CSRF-Token": csrf,
-    },
   };
-});
 
-const httpLink = createHttpLink({
-  uri: "/toby_graphql",
-});
-
-const client = new ApolloClient({
-  cache: createCache(),
-  link: authLink.concat(httpLink),
-  defaultOptions: {
-    mutate: {
-      errorPolicy: "all",
-    },
-    watchQuery: {
-      errorPolicy: "all",
-    },
-  },
-});
-
-// write any prefetched queries to the cache
-if (window.prefetchedQueries) {
-  window.prefetchedQueries.forEach((prefetchedQuery) => {
-    client.writeQuery({
-      query: gql(prefetchedQuery.query),
-      data: prefetchedQuery.result.data,
-    });
+  resources.forEach((r) => {
+    typePolicies.Query.fields[r.queryNameCollection] = relayStylePagination();
   });
-}
 
-export default client;
+  const createCache = () => {
+    return new InMemoryCache({
+      possibleTypes: {},
+      typePolicies,
+    });
+  };
+
+  const authLink = setContext((_, { headers }) => {
+    const csrfElement = document.querySelector("meta[name=csrf-token]");
+    const csrf = csrfElement?.getAttribute("content");
+
+    return {
+      headers: {
+        ...headers,
+        "X-CSRF-Token": csrf,
+      },
+    };
+  });
+
+  const httpLink = createHttpLink({
+    uri: "/toby_graphql",
+  });
+
+  const client = new ApolloClient({
+    cache: createCache(),
+    link: authLink.concat(httpLink),
+    defaultOptions: {
+      mutate: {
+        errorPolicy: "all",
+      },
+      watchQuery: {
+        errorPolicy: "all",
+      },
+    },
+  });
+
+  // write any prefetched queries to the cache
+  if (window.prefetchedQueries) {
+    window.prefetchedQueries.forEach((prefetchedQuery) => {
+      client.writeQuery({
+        query: gql(prefetchedQuery.query),
+        data: prefetchedQuery.result.data,
+      });
+    });
+  }
+
+  return client;
+}

--- a/app/javascript/toby/components/TobyProvider/index.js
+++ b/app/javascript/toby/components/TobyProvider/index.js
@@ -1,6 +1,7 @@
 import React, { createContext, useContext, useMemo } from "react";
 import { useQuery } from "@apollo/client";
 import TOBY_QUERY from "./tobyQuery.graphql";
+import createClient from "../../apolloClient";
 
 export const TobyContext = createContext();
 
@@ -9,7 +10,9 @@ export function useToby() {
 }
 
 export default function TobyProvider({ children }) {
-  const { data, loading, error } = useQuery(TOBY_QUERY);
+  const { data, loading, error } = useQuery(TOBY_QUERY, {
+    client: createClient(),
+  });
 
   const value = useMemo(
     () => ({

--- a/app/javascript/toby/views/resource/EndlessScroll.js
+++ b/app/javascript/toby/views/resource/EndlessScroll.js
@@ -1,0 +1,23 @@
+import React, { useLayoutEffect, useCallback, useRef } from "react";
+
+export default function EndlessScroll({ onLoadMore = () => {} }) {
+  const ref = useRef(null);
+
+  const callback = useCallback(
+    (entries) => {
+      const [entry] = entries;
+      if (entry.isIntersecting) {
+        onLoadMore();
+      }
+    },
+    [onLoadMore],
+  );
+
+  useLayoutEffect(() => {
+    const observer = new IntersectionObserver(callback);
+    observer.observe(ref.current);
+    return () => observer.disconnect();
+  }, [callback]);
+
+  return <div ref={ref} />;
+}

--- a/app/javascript/toby/views/resource/Records.js
+++ b/app/javascript/toby/views/resource/Records.js
@@ -3,7 +3,6 @@ import { Reorder, useDragControls } from "framer-motion";
 import React from "react";
 import { Box, Text } from "@advisable/donut";
 import { Exclamation } from "@styled-icons/heroicons-solid/Exclamation";
-import { useBottomScrollListener } from "react-bottom-scroll-listener";
 import { useFetchResources } from "../../utilities";
 import {
   StyledHeaderRow,
@@ -16,6 +15,7 @@ import Loading from "./Loading";
 import useColumnSizes from "./useColumnSizes";
 import DragHandle from "./DragHandle";
 import useColumnOrder from "./useColumnOrder";
+import EndlessScroll from "./EndlessScroll";
 
 function APIError() {
   return (
@@ -79,17 +79,17 @@ export default function Records({ resource, filters, sortBy, sortOrder }) {
     sortOrder,
   );
 
-  const scrollRef = useBottomScrollListener(() => {
-    if (!loading && !hasNextPage) return;
-    fetchMore({ variables: { cursor: endCursor } });
-  });
-
   const hasNextPage = data?.records.pageInfo.hasNextPage;
   const endCursor = data?.records.pageInfo.endCursor;
   const edges = data?.records.edges || [];
 
+  const handleLoadMore = async () => {
+    if (!loading && !hasNextPage) return;
+    fetchMore({ variables: { cursor: endCursor } });
+  };
+
   return (
-    <StyledScrollContainer ref={scrollRef}>
+    <StyledScrollContainer>
       {/* Dear future developer. I know this inline-block looks random. But its important. */}
       <Box display="inline-block" minWidth="100vw">
         <StyledHeaderRow>
@@ -113,12 +113,15 @@ export default function Records({ resource, filters, sortBy, sortOrder }) {
           {error ? (
             <APIError />
           ) : (
-            <Rows
-              edges={edges}
-              resource={resource}
-              sizeForColumn={sizeForColumn}
-              attributes={orderedAttributes}
-            />
+            <>
+              <Rows
+                edges={edges}
+                resource={resource}
+                sizeForColumn={sizeForColumn}
+                attributes={orderedAttributes}
+              />
+              <EndlessScroll onLoadMore={handleLoadMore} />
+            </>
           )}
           {loading && (
             <Loading


### PR DESCRIPTION
This had been annoying me for a while. The pagination in Toby has been broken because we didn't have the correct type policies in the cache config. I fixed this by moving the toby provider above the Apollo provider and using the initial toby query to create an Apollo client for the provider.

### Reviewer Checklist

- [ ] PR has a clear title and description
- [ ] Manually tested the changes that the PR introduces
- [ ] Changes introduced by the PR are covered by tests of acceptable quality
- [ ] Checked the quality of [commit messages](http://chris.beams.io/posts/git-commit/)