### PR TITLE
Require custom reads to be prefixed with read_

### DIFF
--- a/app/lib/toby/attributes/base_attribute.rb
+++ b/app/lib/toby/attributes/base_attribute.rb
@@ -56,7 +56,8 @@ module Toby
       end
 
       def read(object)
-        return resource.public_send(name, object) if resource.respond_to?(name)
+        read_method = "read_#{name}"
+        return resource.public_send(read_method, object) if resource.respond_to?(read_method)
 
         object.public_send(name)
       end

--- a/app/lib/toby/resources/payment.rb
+++ b/app/lib/toby/resources/payment.rb
@@ -21,7 +21,7 @@ module Toby
       attribute :created_at, Attributes::DateTime, readonly: true
       attribute :updated_at, Attributes::DateTime, readonly: true
 
-      def self.pdf_url(object)
+      def self.read_pdf_url(object)
         object.pdf_url(allow_nil: true)
       end
 


### PR DESCRIPTION
This was causing issues with resources with a name attribute because name is already a method on classes. :doh: