### PR TITLE
Fix flaky bookmark spec

### DIFF
--- a/app/javascript/src/views/CaseStudyArticle/components/SpecialistBar.js
+++ b/app/javascript/src/views/CaseStudyArticle/components/SpecialistBar.js
@@ -39,6 +39,7 @@ export default function SpecialistBar({
 
   return (
     <div
+      data-testid="specialistBar"
       className="sticky left-0 right-0 bg-white h-[72px] shadow transition-all z-20"
       style={{
         top: offset,

--- a/spec/system/bookmarks_articles_spec.rb
+++ b/spec/system/bookmarks_articles_spec.rb
@@ -33,8 +33,8 @@ RSpec.describe "Bookmarks", type: :system do
     expect(page).to have_content(article1.title)
     click_on(article1.title)
     expect(page).to have_current_path("/articles/#{article1.slug}")
-    modal = find_by_test_id("articleModal")
-    within(modal) do
+    specialist_bar = find_by_test_id("specialistBar")
+    within(specialist_bar) do
       find_by_label("Add to Bookmarks").click
     end
     expect(page).to have_content("Added to bookmarks")
@@ -54,7 +54,10 @@ RSpec.describe "Bookmarks", type: :system do
     click_on(article1.title)
     expect(page).to have_current_path("/articles/#{article1.slug}")
     expect(page).to have_content(article1.title)
-    click_button("Remove from Bookmarks")
+    specialist_bar = find_by_test_id("specialistBar")
+    within(specialist_bar) do
+      click_button("Remove from Bookmarks")
+    end
     expect(page).to have_content("Removed from bookmarks")
     click_button("Close modal")
     expect(page).not_to have_content(article1.title)


### PR DESCRIPTION
### Description

Since moving to the modal view, there was now two remove bookmark buttons on the page, one on the feed and one in the modal. I've updated the spec to only check within the specialist bar in the modal.

### Reviewer Checklist

- [ ] PR has a clear title and description
- [ ] Manually tested the changes that the PR introduces
- [ ] Changes introduced by the PR are covered by tests of acceptable quality
- [ ] Checked the quality of [commit messages](http://chris.beams.io/posts/git-commit/)