### PR TITLE
Add ability to skip gcal

### DIFF
--- a/app/lib/google_calendar.rb
+++ b/app/lib/google_calendar.rb
@@ -16,6 +16,8 @@ class GoogleCalendar
     set_up_service
     interview.google_calendar_id.blank? ? create_event(interview) : reschedule_event(interview)
     watch_event(interview)
+  rescue GoogleCalendarError => e
+    raise e unless ENV["GOOGLE_CALENDAR_SKIP"] == "true"
   end
 
   def handle_change(interview)
@@ -27,6 +29,8 @@ class GoogleCalendar
     else
       interview.reschedule!(event.start.date_time)
     end
+  rescue GoogleCalendarError => e
+    raise e unless ENV["GOOGLE_CALENDAR_SKIP"] == "true"
   end
 
   private


### PR DESCRIPTION
Resolves: [Asana](https://app.asana.com/0/search/1201657715104059/1202596867177553/f)

### Description

Introduce `GOOGLE_CALENDAR_SKIP` env var to skip gcal integration.

Mainly intended for local dev use.

### Reviewer Checklist

- [ ] PR has a clear title and description
- [ ] Manually tested the changes that the PR introduces
- [ ] Changes introduced by the PR are covered by tests of acceptable quality
- [ ] Checked the quality of [commit messages](http://chris.beams.io/posts/git-commit/)