### PR TITLE
Only prompt client about agreement message

### DIFF
--- a/app/javascript/src/views/Messages/components/AgreementCreatedMessage.js
+++ b/app/javascript/src/views/Messages/components/AgreementCreatedMessage.js
@@ -319,12 +319,12 @@ export default function AgreementCreatedMessage({ message }) {
   );
 
   useEffect(() => {
-    if (isPending) {
+    if (isPending && viewer.isClient) {
       show();
     } else {
       dismiss();
     }
-  }, [show, dismiss, isPending]);
+  }, [show, dismiss, isPending, viewer.isClient]);
 
   return (
     <BaseMessage message={message} highlight={highlight}>


### PR DESCRIPTION
Resolves: [Ticket](https://app.asana.com/0/1200808264546087/1202628378428160/f)

### Description

Currently this also prompts freelancers when there is a pending agreement but that doesn't really make sense because they can't action it.

### Reviewer Checklist

- [ ] PR has a clear title and description
- [ ] Manually tested the changes that the PR introduces
- [ ] Changes introduced by the PR are covered by tests of acceptable quality
- [ ] Checked the quality of [commit messages](http://chris.beams.io/posts/git-commit/)
