### PR TITLE
Add primary_skill field to Types::CaseStudy::Article

### DIFF
--- a/app/graphql/types/case_study/article.rb
+++ b/app/graphql/types/case_study/article.rb
@@ -32,6 +32,12 @@ module Types
         object.skills.order(created_at: :asc)
       end
 
+      field :primary_skill, Types::Skill, null: true
+      def primary_skill
+        skills = object.skills
+        skills.find(&:primary)&.skill || skills.first&.skill
+      end
+
       field :cover_photo, String, null: true
       def cover_photo
         object.cover_photo.url


### PR DESCRIPTION
### Description

Another one extracted from my branch. We want to display just the primary skill on the article card, this gives me a way to query for just that instead of fetching all the skills and filtering on the frontend. 

### Reviewer Checklist

- [ ] PR has a clear title and description
- [ ] Manually tested the changes that the PR introduces
- [ ] Changes introduced by the PR are covered by tests of acceptable quality
- [ ] Checked the quality of [commit messages](http://chris.beams.io/posts/git-commit/)
