### PR TITLE
Rework populate interests job to trigger feed updated subscription

### DIFF
--- a/app/graphql/mutations/case_study/create_interests.rb
+++ b/app/graphql/mutations/case_study/create_interests.rb
@@ -22,6 +22,8 @@ module Mutations
             ::CaseStudy::Interest.create!(term:, account: current_user.account)
           end
         end
+
+        PopulateInterestArticlesJob.perform_later(interests.map(&:id))
         {interests:}
       end
     end

--- a/app/graphql/subscriptions/base_subscription.rb
+++ b/app/graphql/subscriptions/base_subscription.rb
@@ -3,7 +3,7 @@
 module Subscriptions
   class BaseSubscription < GraphQL::Schema::Subscription
     # include Helpers::Authentication
-    # include CurrentUserUtilities
+    include CurrentUserUtilities
 
     argument_class(Types::BaseArgument)
   end

--- a/app/graphql/subscriptions/feed_updated.rb
+++ b/app/graphql/subscriptions/feed_updated.rb
@@ -1,0 +1,16 @@
+# frozen_string_literal: true
+
+module Subscriptions
+  class FeedUpdated < Subscriptions::BaseSubscription
+    subscription_scope :current_account_id
+    field :ok, Boolean, null: false
+
+    def subscribe
+      :no_response
+    end
+
+    def update
+      {ok: true}
+    end
+  end
+end

--- a/app/graphql/subscriptions/received_message.rb
+++ b/app/graphql/subscriptions/received_message.rb
@@ -2,8 +2,6 @@
 
 module Subscriptions
   class ReceivedMessage < Subscriptions::BaseSubscription
-    include CurrentUserUtilities
-
     description "A message was received on current_account's conversation"
 
     subscription_scope :current_account_id

--- a/app/graphql/types/subscription_type.rb
+++ b/app/graphql/types/subscription_type.rb
@@ -5,5 +5,6 @@ module Types
     description "Subscription type"
 
     field :received_message, subscription: Subscriptions::ReceivedMessage
+    field :feed_updated, subscription: Subscriptions::FeedUpdated
   end
 end

--- a/app/jobs/populate_interest_articles_job.rb
+++ b/app/jobs/populate_interest_articles_job.rb
@@ -3,7 +3,10 @@
 class PopulateInterestArticlesJob < ApplicationJob
   queue_as :case_studies
 
-  def perform(interest)
-    interest.find_articles!
+  def perform(interest_ids)
+    interests = CaseStudy::Interest.where(id: interest_ids)
+    account = interests.first.account
+    interests.each(&:find_articles!)
+    AdvisableSchema.subscriptions.trigger("feedUpdated", {}, {}, scope: account.id)
   end
 end

--- a/app/models/case_study/interest.rb
+++ b/app/models/case_study/interest.rb
@@ -16,20 +16,12 @@ module CaseStudy
     validates :term, presence: true
     validates :term, uniqueness: {case_sensitive: false, scope: :account_id}
 
-    after_create :populate_articles
-
     def find_articles!
       return if interest_articles.any?
 
       results = articles_for_interest.first(MAX_RESULTS)
       interest_articles.insert_all!(results) # rubocop:disable Rails/SkipsModelValidations
       update!(treshold: results.last[:similarity])
-    end
-
-    private
-
-    def populate_articles
-      PopulateInterestArticlesJob.perform_later(self)
     end
   end
 end

--- a/spec/jobs/populate_interest_articles_job_spec.rb
+++ b/spec/jobs/populate_interest_articles_job_spec.rb
@@ -3,7 +3,8 @@
 require "rails_helper"
 
 RSpec.describe PopulateInterestArticlesJob do
-  let(:interest) { create(:case_study_interest) }
+  let(:interest1) { create(:case_study_interest) }
+  let(:interest2) { create(:case_study_interest) }
   let(:embedding1) { create(:case_study_embedding) }
   let(:embedding2) { create(:case_study_embedding) }
   let!(:article1) { embedding1.article }
@@ -11,9 +12,14 @@ RSpec.describe PopulateInterestArticlesJob do
 
   before { allow_any_instance_of(OpenAiInteractor).to receive(:query_embedding_for).and_return([-0.024432803, 0.02814213, 0.02230821]) }
 
-  it "populates articles" do
-    expect(interest.interest_articles).to be_blank
-    described_class.perform_now(interest)
-    expect(interest.articles).to match_array([article1, article2])
+  it "populates articles and triggers feedUpdated subscription" do
+    # rubocop:disable RSpec/MessageChain
+    expect(AdvisableSchema).to receive_message_chain(:subscriptions, :trigger).with("feedUpdated", {}, {}, scope: interest1.account.id)
+    # rubocop:enable RSpec/MessageChain
+    expect(interest1.interest_articles).to be_blank
+    expect(interest2.interest_articles).to be_blank
+    described_class.perform_now([interest1.id, interest2.id])
+    expect(interest1.articles).to match_array([article1, article2])
+    expect(interest2.articles).to match_array([article1, article2])
   end
 end


### PR DESCRIPTION
I updated the way the PopulateInterestArticlesJob works to take a list of interests instead of just a single interest. This was because there was too many race condition issues when trying to determine whether to fire the feedUpdated subscription when they were separate. 

### Reviewer Checklist

- [ ] PR has a clear title and description
- [ ] Manually tested the changes that the PR introduces
- [ ] Changes introduced by the PR are covered by tests of acceptable quality
- [ ] Checked the quality of [commit messages](http://chris.beams.io/posts/git-commit/)