### PR TITLE
Add custom host to development environment

### DIFF
--- a/config/environments/development.rb
+++ b/config/environments/development.rb
@@ -35,7 +35,7 @@ Rails.application.configure do
     config.cache_store = :null_store
   end
 
-  config.hosts += [/.+\.ngrok\.io/, "advisable.test", ENV["CUSTOM_DEV_HOST"]]
+  config.hosts += [/.+\.ngrok\.io/, "advisable.test", ENV.fetch("CUSTOM_DEV_HOST", nil)].compact
 
   # Store uploaded files on the local file system (see config/storage.yml for options).
   # config.active_storage.service = :amazon


### PR DESCRIPTION
### Description

Include `ENV[“CUSTOM_DEV_HOST”]` so we could do development from virtual machines. In my case I want to connect to my digital ocean vm using iPad.
