### PR TITLE
Update similar articles to use new case study card

### DIFF
--- a/app/javascript/src/views/CaseStudyArticleNew/components/SimilarArticles.js
+++ b/app/javascript/src/views/CaseStudyArticleNew/components/SimilarArticles.js
@@ -1,5 +1,5 @@
 import React from "react";
-import FeedItem from "src/views/Feed/components/FeedItem";
+import CaseStudyCard from "src/views/Explore/CaseStudyCard";
 
 export default function SimilarArticles({ articles, ...props }) {
   return (
@@ -7,9 +7,9 @@ export default function SimilarArticles({ articles, ...props }) {
       <h4 className="mb-5 text-2xl font-medium tracking-tight">
         Similar projects
       </h4>
-      <div className="space-y-6">
+      <div className="grid grid-cols-1 gap-6 lg:grid-cols-2 lg:gap-8">
         {articles.map((article) => (
-          <FeedItem key={article.id} article={article} />
+          <CaseStudyCard key={article.id} article={article} />
         ))}
       </div>
     </div>

--- a/app/javascript/src/views/CaseStudyArticleNew/queries/article.gql
+++ b/app/javascript/src/views/CaseStudyArticleNew/queries/article.gql
@@ -32,13 +32,6 @@ query Article($slug: ID!) {
     }
     similar {
       ...ArticleFields
-      industries {
-        id
-        industry {
-          id
-          name
-        }
-      }
     }
     review {
       id

--- a/app/models/case_study/article.rb
+++ b/app/models/case_study/article.rb
@@ -64,7 +64,7 @@ module CaseStudy
       "/articles/#{slug_or_uid}"
     end
 
-    def similar(limit: 3, exclude_specialist: nil)
+    def similar(limit: 4, exclude_specialist: nil)
       similar_ids = Rails.cache.fetch("case_study_article_similar_#{id}", expires_in: 1.day) do
         Embedding.ordered_articles_for(embedding.vector).pluck(:article_id).reject { |article_id| id == article_id }
       end


### PR DESCRIPTION
The similar articles at the bottom of a case study were still using the old feed style list of articles. There is definitely some design improvements we can make here as the cards blend into the background a bit too much but I definitely think it makes sense to start using the same component to represent a case study. This also enables us to remove all of the old feed code.

### Reviewer Checklist

- [ ] PR has a clear title and description
- [ ] Manually tested the changes that the PR introduces
- [ ] Changes introduced by the PR are covered by tests of acceptable quality
- [ ] Checked the quality of [commit messages](http://chris.beams.io/posts/git-commit/)

### Screenshots

**Before**
![image](https://user-images.githubusercontent.com/1512593/186129999-0a4887af-8e9f-40a3-9ea4-eec4d01179f6.png)

**After**
![image](https://user-images.githubusercontent.com/1512593/186130082-03f43d79-794a-4dc6-bcf3-3d6051d01ab3.png)

