### PR TITLE
Hide case study primary skill on the topic pages

### DIFF
--- a/app/javascript/src/views/Explore/CaseStudyCard.js
+++ b/app/javascript/src/views/Explore/CaseStudyCard.js
@@ -51,7 +51,12 @@ function primarySkillForArticle(article) {
   return primarySkill.skill;
 }
 
-export default function CaseStudyCard({ article, delay, allowPublicAccess }) {
+export default function CaseStudyCard({
+  article,
+  delay,
+  allowPublicAccess,
+  showSkill = true,
+}) {
   const viewer = useViewer();
   const location = useLocation();
   const [tapping, setTapping] = useState(false);
@@ -108,7 +113,7 @@ export default function CaseStudyCard({ article, delay, allowPublicAccess }) {
           onMouseUp={() => setTapping(false)}
           className="p-6 rounded-xl no-tap-highlight case-study-card-content"
         >
-          {primarySkill && (
+          {showSkill && primarySkill && (
             <div className={skillClasses({ color: primarySkill.color })}>
               {primarySkill.name}
             </div>

--- a/app/javascript/src/views/Explore/CaseStudyGrid.js
+++ b/app/javascript/src/views/Explore/CaseStudyGrid.js
@@ -4,7 +4,12 @@ import CaseStudyCard from "./CaseStudyCard";
 
 const PAGE_SIZE = 15;
 
-export default function CaseStudyGrid({ loading, results, allowPublicAccess }) {
+export default function CaseStudyGrid({
+  loading,
+  results,
+  allowPublicAccess,
+  showSkill,
+}) {
   return (
     <div className="grid grid-cols-1 gap-6 md:grid-cols-2 lg:grid-cols-3 lg:gap-8">
       {results.map((result, i) => (
@@ -14,6 +19,7 @@ export default function CaseStudyGrid({ loading, results, allowPublicAccess }) {
           fadeIn={loading}
           delay={0.05 * (i % PAGE_SIZE)}
           allowPublicAccess={allowPublicAccess}
+          showSkill={showSkill}
         />
       ))}
       {loading && (

--- a/app/javascript/src/views/Explore/Topic.js
+++ b/app/javascript/src/views/Explore/Topic.js
@@ -33,7 +33,7 @@ export default function Topic() {
 
   if (isNotFound(error)) {
     return (
-      <div className="w-[300px] py-12 mx-auto text-center">
+      <div className="py-12 mx-auto text-center w-[300px]">
         <LostIllustration width="200px" className="mx-auto mb-8" />
         <h4 className="font-semibold">Oops</h4>
         <p>We can't seem to find the page you're looking for.</p>
@@ -48,8 +48,10 @@ export default function Topic() {
         description={topic.description}
         loading={!topic.name && loading}
       />
-      <CaseStudyGrid loading={loading} results={results} />
-      {viewer && pageInfo?.hasNextPage && <EndlessScroll onLoadMore={handleLoadMore} />}
+      <CaseStudyGrid loading={loading} results={results} showSkill={false} />
+      {viewer && pageInfo?.hasNextPage && (
+        <EndlessScroll onLoadMore={handleLoadMore} />
+      )}
       {viewer && !loading && !pageInfo?.hasNextPage && (
         <FeedFooter>You've reached the end of the list.</FeedFooter>
       )}


### PR DESCRIPTION
Users were getting confused when they were inside of topic and seeing a different primary skill. e.g 'SEO' topic but the primary skill is 'Content Marketing'.

### Reviewer Checklist

- [ ] PR has a clear title and description
- [ ] Manually tested the changes that the PR introduces
- [ ] Changes introduced by the PR are covered by tests of acceptable quality
- [ ] Checked the quality of [commit messages](http://chris.beams.io/posts/git-commit/)
