### PR TITLE
Overlay CTA over end of feed

### DIFF
--- a/app/javascript/src/components/SignupCTA/index.js
+++ b/app/javascript/src/components/SignupCTA/index.js
@@ -87,27 +87,36 @@ function Map() {
 
 export default function SignupCTA() {
   return (
-    <div className="relative py-20 px-16 mt-12 rounded-xl shadow-xl signupCTA bg-blue900">
-      <div className="relative z-10">
-        <h1 className="mb-5 font-serif text-5xl font-semibold tracking-tight leading-tight text-white max-w-[520px]">
-          Explore 100s of case studies for free
-        </h1>
-        <p className="mb-12 text-lg leading-relaxed text-white opacity-80 w-[460px]">
-          Get free access to our full library of SaaS marketing case studies.
-          You only pay when you hire someone you discover through us!
-        </p>
-        <div className="flex gap-4">
-          <Link to="/clients/join">
-            <Button size="lg">Get full access</Button>
-          </Link>
-          <Link to="/freelancers/join">
-            <Button variant="whiteOutlined" size="lg">
-              Share your project
-            </Button>
-          </Link>
+    <div className="relative -mt-[500px]">
+      <div className="pointer-events-none h-[120px]" />
+      <div
+        style={{
+          boxShadow:
+            "0 12px 40px -8px rgb(0 0 0 / .6), 0 -40px 40px -24px rgb( 0 0 0 / .28)",
+        }}
+        className="relative py-20 px-16 -mx-8 rounded-2xl signupCTA bg-blue900"
+      >
+        <div className="relative z-10">
+          <h1 className="mb-5 font-serif text-5xl font-semibold tracking-tight leading-tight text-white max-w-[520px]">
+            Explore 100s of case studies for free
+          </h1>
+          <p className="mb-12 text-lg leading-relaxed text-white opacity-80 w-[460px]">
+            Get free access to our full library of SaaS marketing case studies.
+            You only pay when you hire someone you discover through us!
+          </p>
+          <div className="flex gap-4">
+            <Link to="/clients/join">
+              <Button size="lg">Get full access</Button>
+            </Link>
+            <Link to="/freelancers/join">
+              <Button variant="whiteOutlined" size="lg">
+                Share your project
+              </Button>
+            </Link>
+          </div>
         </div>
+        <Map />
       </div>
-      <Map />
     </div>
   );
 }

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -51,6 +51,7 @@ module.exports = {
         md: "1rem",
         lg: "1.5rem",
         xl: "2rem",
+        "2xl": "2.5rem",
       },
       transitionProperty: {
         height: "height",
@@ -76,7 +77,7 @@ module.exports = {
     // This snippet defines each color in the tailwind config as a CSS variable
     // on :root. This can be useful when you want to use a color outside of what
     // tailwind provides. e.g working with SVG's.
-    function ({ addBase, theme }) {
+    function({ addBase, theme }) {
       function extractColorVars(colorObj, colorGroup = "") {
         return Object.keys(colorObj).reduce((vars, colorKey) => {
           const value = colorObj[colorKey];


### PR DESCRIPTION
Resolves: [Ticket](https://app.asana.com/0/1200808264546087/1202867907178065/f)

### Description

Overlays the CTA over the last row of results in the feed. This doesn't work well on mobile as there is a gap in the end of the feed but I plan to do a separate PR to package all the homepage mobile improvements together.

![image](https://user-images.githubusercontent.com/1512593/186863410-351acb1e-e65c-430c-b198-50117ce421ee.png)


### Reviewer Checklist

- [ ] PR has a clear title and description
- [ ] Manually tested the changes that the PR introduces
- [ ] Changes introduced by the PR are covered by tests of acceptable quality
- [ ] Checked the quality of [commit messages](http://chris.beams.io/posts/git-commit/)