### PR TITLE
Add support for podcast content types

### DIFF
--- a/app/javascript/src/views/CaseStudyArticle/components/ArticleContent.js
+++ b/app/javascript/src/views/CaseStudyArticle/components/ArticleContent.js
@@ -4,12 +4,14 @@ import Heading from "./Heading";
 import Paragraph from "./Paragraph";
 import { useLocation } from "react-router-dom";
 import LimitedContentSignup from "./LimitedContentSignup";
+import Podcast from "./PodcastContent";
 
 const CONTENT_TYPES = {
   Images,
   Heading,
   Results: null,
   Paragraph,
+  Podcast,
 };
 
 function CaseStudyContentBlock({ element, ...props }) {

--- a/app/javascript/src/views/CaseStudyArticle/components/PodcastContent.js
+++ b/app/javascript/src/views/CaseStudyArticle/components/PodcastContent.js
@@ -1,0 +1,17 @@
+import React, { useLayoutEffect, useRef } from "react";
+
+export default function PodcastContent({ id, url }) {
+  const container = useRef();
+
+  useLayoutEffect(() => {
+    if (!container.current) return;
+    const scriptSrc = `${url}.js?container_id=${id}&player=small`;
+    const script = document.createElement("script");
+    script.setAttribute("type", "text/javascript");
+    script.setAttribute("charset", "utf-8");
+    script.setAttribute("src", scriptSrc);
+    container.current.after(script);
+  }, [id, url]);
+
+  return <div id={id} ref={container} className="mb-10" />;
+}

--- a/app/javascript/src/views/CaseStudyArticle/queries/article.gql
+++ b/app/javascript/src/views/CaseStudyArticle/queries/article.gql
@@ -28,6 +28,9 @@ query Article($slug: ID!) {
             url
           }
         }
+        ... on Podcast {
+          url
+        }
       }
     }
     similar {


### PR DESCRIPTION
Resolves: [Ticket](https://app.asana.com/0/1200808264546087/1202889676708987/f)

### Description

Allows us to have embedded podcasts within the case study content. You can create a podcast content type by going to the admin editor for an article. e.g http://localhost:3000/admin/articles/1/edit, scroll down to the background section, Add new content , select podcast and then provide the url for an episode. e.g https://thefirstmarketerpodcast.buzzsprout.com/2011220/10921150-riddhi-shah-and-gusto-content-that-turned-a-crisis-into-an-opportunity

### Reviewer Checklist

- [ ] PR has a clear title and description
- [ ] Manually tested the changes that the PR introduces
- [ ] Changes introduced by the PR are covered by tests of acceptable quality
- [ ] Checked the quality of [commit messages](http://chris.beams.io/posts/git-commit/)

### Screenshots
![image](https://user-images.githubusercontent.com/1512593/187647227-e64a399d-940a-4c7c-8f8e-ec5074fe3851.png)
