### PR TITLE
Fix blured case study cards on mobile

### DIFF
--- a/app/javascript/src/views/Explore/CaseStudyGrid.js
+++ b/app/javascript/src/views/Explore/CaseStudyGrid.js
@@ -1,4 +1,5 @@
-import React from "react";
+import React, { useMemo } from "react";
+import { useBreakpoint } from "src/../../../donut/src";
 import useViewer from "src/hooks/useViewer";
 import CardSkeleton from "./CardSkeleton";
 import CaseStudyCard from "./CaseStudyCard";
@@ -7,17 +8,30 @@ const PAGE_SIZE = 15;
 
 export default function CaseStudyGrid({ loading, results, showSkill }) {
   const viewer = useViewer();
+  const isTablet = useBreakpoint("mUp");
+  const isLarge = useBreakpoint("lUp");
+
+  const columns = useMemo(() => {
+    if (isLarge) return 3;
+    if (isTablet) return 2;
+    return 1;
+  }, [isTablet, isLarge]);
+
+  const articles = useMemo(() => {
+    if (viewer) return results;
+    return results.slice(0, results.length - (results.length % columns));
+  }, [viewer, columns, results]);
 
   return (
     <div className="grid grid-cols-1 gap-6 md:grid-cols-2 lg:grid-cols-3 lg:gap-8">
-      {results.map((result, i) => (
+      {articles.map((result, i) => (
         <CaseStudyCard
           key={result.id}
           article={result}
           fadeIn={loading}
           delay={0.05 * (i % PAGE_SIZE)}
           showSkill={showSkill}
-          blurred={!viewer && i > results.length - 4}
+          blurred={!viewer && i > articles.length - (columns + 1)}
         />
       ))}
       {loading && (


### PR DESCRIPTION
Before we were just blurring the last 3 cards when not logged in. This obviously only works on mobile. This change will clip the results in the grid to the number of columns and only blur the last row.

before
![image](https://user-images.githubusercontent.com/1512593/189324581-61678185-657c-4148-88ec-bf26a9d8624c.png)

after
![image](https://user-images.githubusercontent.com/1512593/189324641-b99b51d4-4fb6-4ca9-8754-99876246ff81.png)


### Reviewer Checklist

- [ ] PR has a clear title and description
- [ ] Manually tested the changes that the PR introduces
- [ ] Changes introduced by the PR are covered by tests of acceptable quality
- [ ] Checked the quality of [commit messages](http://chris.beams.io/posts/git-commit/)