### PR TITLE
Fix ordering of article content

### DIFF
--- a/app/views/admin/contents/_base.html.erb
+++ b/app/views/admin/contents/_base.html.erb
@@ -1,8 +1,8 @@
-<div data-controller="inline-editing" data-inline-editing-edit-url-value="<%= edit_admin_content_path(content) %>">
-  <turbo-frame id="<%= dom_id(content) %>" data-inline-editing-target="turboFrame" data-sortable-update-url="<%= move_admin_content_path(content) %>">
+<div data-controller="inline-editing" data-inline-editing-edit-url-value="<%= edit_admin_content_path(content) %>" data-sortable-update-url="<%= move_admin_content_path(content) %>">
+  <turbo-frame id="<%= dom_id(content) %>" data-inline-editing-target="turboFrame">
     <div class="group flex relative">
       <div class="absolute handle top-0 -left-10 text-gray-900 mr-1">
-        <div class="hidden group-hover:flex pt-1 h-16 w-10 justify-center cursor-move">
+        <div class="hidden group-hover:flex pt-1.5 h-16 w-10 justify-center cursor-move">
           <svg xmlns="http://www.w3.org/2000/svg" class="h-6 w-6 text-neutral-500" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="2">
             <path stroke-linecap="round" stroke-linejoin="round" d="M4 6h16M4 12h16M4 18h16" />
           </svg>

--- a/app/views/admin/contents/_edit.html.erb
+++ b/app/views/admin/contents/_edit.html.erb
@@ -1,12 +1,5 @@
 <turbo-frame id="<%= dom_id(content) %>" data-sortable-update-url="<%= move_admin_content_path(content) %>">
   <div class="group flex relative">
-    <div class="absolute handle top-0 -left-10 text-gray-900 mr-1">
-      <div class="hidden group-hover:flex pt-1 h-16 w-10 justify-center cursor-move">
-        <svg xmlns="http://www.w3.org/2000/svg" class="h-6 w-6 text-neutral-500" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="2">
-          <path stroke-linecap="round" stroke-linejoin="round" d="M4 6h16M4 12h16M4 18h16" />
-        </svg>
-      </div>
-    </div>
     <div class="w-full">
       <%= render "admin/contents/#{content.class.name.demodulize.underscore}_form", content: content %>
     </div>


### PR DESCRIPTION
So looks like I made things like nice but pretty much broke everything 🤣. The ordering was working from the UI but not saving. This is because the sortable controller needs the children to define the data-sortable-url attribute and we wrapped that with the inline editing controller div.

### Reviewer Checklist

- [ ] PR has a clear title and description
- [ ] Manually tested the changes that the PR introduces
- [ ] Changes introduced by the PR are covered by tests of acceptable quality
- [ ] Checked the quality of [commit messages](http://chris.beams.io/posts/git-commit/)
